### PR TITLE
BRISQUE: Data ranges.

### DIFF
--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -173,7 +173,7 @@ def brisque(x: torch.Tensor,
     _validate_input(input_tensors=x, allow_5d=False)
     x = _adjust_dimensions(input_tensors=x)
 
-    assert data_range >= x.max(), 'Expected data range greater or equal maximum value.'
+    assert data_range >= x.max(), f'Expected data range greater or equal maximum value, got {data_range} and {x.max()}.'
     x = x * 255. / data_range
 
     if x.size(1) == 3:

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -173,7 +173,8 @@ def brisque(x: torch.Tensor,
     _validate_input(input_tensors=x, allow_5d=False)
     x = _adjust_dimensions(input_tensors=x)
 
-    x = x / data_range
+    assert data_range >= x.max(), 'Expected data range greater or equal maximum value.'
+    x = x * 255. / data_range
 
     if x.size(1) == 3:
         # rgb_to_grey - weights to transform RGB image to grey

--- a/tests/test_brisque.py
+++ b/tests/test_brisque.py
@@ -46,20 +46,23 @@ def test_brisque_raises_if_wrong_reduction(prediction_grey: torch.Tensor) -> Non
 
 
 def test_brisque_values_grey(prediction_grey: torch.Tensor) -> None:
-    score = brisque(prediction_grey, reduction='none')
-    score_baseline = torch.tensor([BRISQUE().get_score(img.squeeze().numpy()) for img in prediction_grey])
-    assert torch.isclose(score, score_baseline, atol=1e-1).all(), f'Expected values to be equal to ' \
-                                                                  f'baseline prediction.' \
-                                                                  f'got {score} and {score_baseline}'
+    score = brisque(prediction_grey, reduction='none', data_range=1.)
+    score_baseline = torch.tensor([BRISQUE().get_score((img * 255).type(torch.uint8).squeeze().numpy())
+                                   for img in prediction_grey])
+    assert torch.isclose(score, score_baseline, atol=1e-1, rtol=1e-2).all(), f'Expected values to be equal to ' \
+                                                                             f'baseline prediction.' \
+                                                                             f'got {score} and {score_baseline}'
 
 
 def test_brisque_values_RGB(prediction_RGB: torch.Tensor) -> None:
-    score = brisque(prediction_RGB, reduction='none')
-    score_baseline = torch.tensor([BRISQUE().get_score(img.squeeze().permute(1, 2, 0).numpy()[..., ::-1])
-                                   for img in prediction_RGB])
-    assert torch.isclose(score, score_baseline, atol=1e-1).all(), f'Expected values to be equal to ' \
-                                                                  f'baseline prediction.' \
-                                                                  f'got {score} and {score_baseline}'
+    score = brisque(prediction_RGB, reduction='none', data_range=1.)
+    score_baseline = [BRISQUE().get_score((img * 255).type(torch.uint8).squeeze().permute(1, 2, 0).numpy()[..., ::-1])
+                      for img in prediction_RGB]
+    assert torch.isclose(score,
+                         torch.tensor((score_baseline)),
+                         atol=1e-1, rtol=1e-3).all(), f'Expected values to be equal to ' \
+                                                      f'baseline prediction.' \
+                                                      f'got {score} and {score_baseline}'
 
 
 def test_brisque_all_zeros_or_ones() -> None:

--- a/tests/test_brisque.py
+++ b/tests/test_brisque.py
@@ -49,7 +49,7 @@ def test_brisque_values_grey(prediction_grey: torch.Tensor) -> None:
     score = brisque(prediction_grey, reduction='none', data_range=1.)
     score_baseline = torch.tensor([BRISQUE().get_score((img * 255).type(torch.uint8).squeeze().numpy())
                                    for img in prediction_grey])
-    assert torch.isclose(score, score_baseline, atol=1e-1, rtol=1e-2).all(), f'Expected values to be equal to ' \
+    assert torch.isclose(score, score_baseline, atol=1e-1, rtol=1e-3).all(), f'Expected values to be equal to ' \
                                                                              f'baseline prediction.' \
                                                                              f'got {score} and {score_baseline}'
 
@@ -59,7 +59,7 @@ def test_brisque_values_RGB(prediction_RGB: torch.Tensor) -> None:
     score_baseline = [BRISQUE().get_score((img * 255).type(torch.uint8).squeeze().permute(1, 2, 0).numpy()[..., ::-1])
                       for img in prediction_RGB]
     assert torch.isclose(score,
-                         torch.tensor((score_baseline)),
+                         torch.tensor(score_baseline),
                          atol=1e-1, rtol=1e-3).all(), f'Expected values to be equal to ' \
                                                       f'baseline prediction.' \
                                                       f'got {score} and {score_baseline}'


### PR DESCRIPTION
Closes #108 

## Proposed Changes

  - Changed data range which is used for estimation of BRISQUE score;
  - Changed tests in accordance to the proper data range.