### PR TITLE
Test coverate info

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -34,11 +34,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest, \
+                      pytest-cov, \
+                      tensorflow, \
+                      libsvm, \
+                      pybrisque, \
+                      scikit-image
       - name: Test with pytest
         run: |
-          pip install pytest
-          pip install tensorflow
-          pip install libsvm
-          pip install pybrisque
-          pip install scikit-image
           pytest

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,7 +42,7 @@ jobs:
                       scikit-image
       - name: Test with pytest
         run: |
-          pytest -x --cov=./ --cov-report=xml
+          pytest -x --cov=./piq --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
+          # Upload codecov reports only from a pipeline for a single version
+          python-version: 3.6
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,4 +42,12 @@ jobs:
                       scikit-image
       - name: Test with pytest
         run: |
-          pytest
+          pytest -x --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -10,6 +10,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      USING_COVERAGE: '3.6'
+
     strategy:
       max-parallel: 4
       matrix:
@@ -44,10 +47,10 @@ jobs:
         run: |
           pytest -x --cov=./piq --cov-report=xml
       - name: Upload coverage to Codecov
+        # Upload codecov reports only from a pipeline for a single version defined in the env variable
+        if: "contains(env.USING_COVERAGE, matrix.python-version)"
         uses: codecov/codecov-action@v1
         with:
-          # Upload codecov reports only from a pipeline for a single version
-          python-version: 3.6
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -34,11 +34,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest, \
-                      pytest-cov, \
-                      tensorflow, \
-                      libsvm, \
-                      pybrisque, \
+          pip install pytest \
+                      pytest-cov \
+                      tensorflow \
+                      libsvm \
+                      pybrisque \
                       scikit-image
       - name: Test with pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![License][license-shield]][license-url]
 [![PyPI version][pypi-version-shield]][pypi-version-url]  
 ![CI flake-8 style check][ci-flake-8-style-check-shield]
-![CI testing][ci-testing]    
+![CI testing][ci-testing]
+[![codecov][codecov-shield]][codecov-url]  
 [![Quality Gate Status][quality-gate-status-shield]][quality-gate-status-url]
 [![Maintainability Rating][maintainability-raiting-shield]][maintainability-raiting-url]
 [![Reliability Rating][reliability-rating-badge]][reliability-rating-url]
@@ -479,3 +480,5 @@ Other projects by PhotoSynthesis Team:
 [maintainability-raiting-url]: https://sonarcloud.io/dashboard?id=photosynthesis-team_photosynthesis.metrics
 [reliability-rating-badge]: https://sonarcloud.io/api/project_badges/measure?project=photosynthesis-team_photosynthesis.metrics&metric=reliability_rating
 [reliability-rating-url]:https://sonarcloud.io/dashboard?id=photosynthesis-team_photosynthesis.metrics
+[codecov-shield]:https://codecov.io/gh/photosynthesis-team/piq/branch/master/graph/badge.svg
+[codecov-url]:https://codecov.io/gh/photosynthesis-team/piq

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches:               # branch names that can post comment
+    - "master"

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,6 @@ comment:
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
+  require_head: no        # [yes :: must have a head report to post]
   branches:               # branch names that can post comment
     - "master"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,19 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,8 +12,6 @@ coverage:
         flags:
           - unit
         # advanced
-        branches:
-          - master
         if_not_found: success
         if_ci_failed: error
         informational: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,5 +34,3 @@ comment:
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: no        # [yes :: must have a base report to post]
   require_head: no        # [yes :: must have a head report to post]
-  branches:               # branch names that can post comment
-    - "master"

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
         flags:
           - unit
         # advanced
+        branches: master
         if_not_found: success
         if_ci_failed: error
         informational: false
@@ -29,6 +30,7 @@ parsers:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
+  branches: *
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: no        # [yes :: must have a base report to post]
   require_head: no        # [yes :: must have a head report to post]

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,23 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 5%
+        base: auto
+        flags:
+          - unit
+        # advanced
+        branches:
+          - master
+        if_not_found: success
+        if_ci_failed: error
+        informational: false
+        only_pulls: false
+
 
 parsers:
   gcov:


### PR DESCRIPTION
Closes #84 

## Proposed Changes

  - Add test coverage info to the testing CI pipeline
  - Integration with [codecov](https://codecov.io/) via GitHub Actions
  - Display of coverage info with a badge in the README