### PR TITLE
Bugfix: relax the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ prediction = torch.rand(3, 3, 256, 256)
 brisque_index: torch.Tensor = brisque(prediction, data_range=1.)
 ```
 
-In order to use BRISQUE as a loss function, use corresponding PyTorch module:
+In order to use BRISQUE as a loss function, use corresponding PyTorch module. 
+
+Note: the back propagation is not available using `torch==1.5.0`. Update the environment with latest `torch` and `torchvision`.
 ```python
 import torch
 from piq import BRISQUELoss

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
 requirements:
   build:
     - python
-    - pytorch>=1.2.0,!=1.5.0
-    - torchvision>=0.4.0,!=0.6.0
+    - pytorch>=1.2.0
+    - torchvision>=0.4.0
     - scipy==1.3.3
     - gudhi>=3.2
   run:
     - python
-    - pytorch>=1.2.0,!=1.5.0
-    - torchvision>=0.4.0,!=0.6.0
+    - pytorch>=1.2.0
+    - torchvision>=0.4.0
     - scipy==1.3.3
     - gudhi>=3.2
 

--- a/piq/__init__.py
+++ b/piq/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from .ssim import ssim, multi_scale_ssim, SSIMLoss, MultiScaleSSIMLoss
 from .msid import MSID

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -42,7 +42,7 @@ def brisque(x: torch.Tensor,
         .. [1] Anish Mittal et al. "No-Reference Image Quality Assessment in the Spatial Domain",
         https://live.ece.utexas.edu/publications/2012/TIP%20BRISQUE.pdf
     """
-    if torch.__version__ == '1.5.0':
+    if '1.5.0' in torch.__version__:
         warnings.warn(f'BRISQUE does not support back propagation due to bug in torch={torch.__version__}.'
                       f'Update torch to the latest version to access full functionality of the BRIQSUE.'
                       f'More info is available at https://github.com/photosynthesis-team/piq/pull/79 and'

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -8,6 +8,7 @@ Credits:
     https://github.com/bukalapak/pybrisque
 """
 from typing import Union, Tuple
+import warnings
 import torch
 from torch.nn.modules.loss import _Loss
 from torch.utils.model_zoo import load_url
@@ -37,6 +38,12 @@ def brisque(x: torch.Tensor,
         .. [1] Anish Mittal et al. "No-Reference Image Quality Assessment in the Spatial Domain",
         https://live.ece.utexas.edu/publications/2012/TIP%20BRISQUE.pdf
     """
+    if torch.__version__ == '1.5.0':
+        warnings.warn(f'BRISQUE does not support back propagation due to bug in torch={torch.__version__}.'
+                      f'Update torch to the latest version to access full functionality of the BRIQSUE.'
+                      f'More info is available at https://github.com/photosynthesis-team/piq/pull/79 and'
+                      f'https://github.com/pytorch/pytorch/issues/38869.')
+
     _validate_input(input_tensors=x, allow_5d=False, kernel_size=kernel_size)
     x = _adjust_dimensions(input_tensors=x)
 

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -34,6 +34,10 @@ def brisque(x: torch.Tensor,
     Returns:
         Value of BRISQUE index.
 
+    Note:
+        The back propagation is not available using torch=1.5.0 due to bug in argmin/argmax back propagation.
+        Update the torch and torchvision to the latest versions.
+
     References:
         .. [1] Anish Mittal et al. "No-Reference Image Quality Assessment in the Spatial Domain",
         https://live.ece.utexas.edu/publications/2012/TIP%20BRISQUE.pdf
@@ -97,6 +101,10 @@ class BRISQUELoss(_Loss):
         >>> target = torch.rand(3, 3, 256, 256)
         >>> output = loss(prediction)
         >>> output.backward()
+
+    Note:
+        The back propagation is not available using torch=1.5.0 due to bug in argmin/argmax back propagation.
+        Update the torch and torchvision to the latest versions.
 
     References:
         .. [1] Anish Mittal et al. "No-Reference Image Quality Assessment in the Spatial Domain",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.2.0,!=1.5.0
-torchvision>=0.4.0,!=0.6.0
+torch>=1.2.0
+torchvision>=0.4.0
 scipy==1.3.3
 gudhi>=3.2


### PR DESCRIPTION
Closes #143 
The problem was related to the upgrade of the environment with `torch` incompatible with CUDA. 
## Proposed Changes

  - made requirements on `pytorch` and `torchvision` less strict
  - added warning to the BRISQUE score that backprop is not available using `torch==1.5.0'
  - added notes to the docstring and readme
