### PR TITLE
CI testing: speeding up testing

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,8 +42,7 @@ jobs:
                       tensorflow \
                       libsvm \
                       pybrisque \
-                      scikit-image \
-                      scipy==1.3.3
+                      scikit-image
       - name: Test with pytest
         run: |
           pytest -x --cov=./piq --cov-report=xml

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -43,7 +43,7 @@ jobs:
                       libsvm \
                       pybrisque \
                       scikit-image \
-                      scipy=1.3.3
+                      scipy==1.3.3
       - name: Test with pytest
         run: |
           pytest -x --cov=./piq --cov-report=xml

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -42,7 +42,8 @@ jobs:
                       tensorflow \
                       libsvm \
                       pybrisque \
-                      scikit-image
+                      scikit-image \
+                      scipy=1.3.3
       - name: Test with pytest
         run: |
           pytest -x --cov=./piq --cov-report=xml

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -43,6 +43,7 @@ jobs:
                       libsvm \
                       pybrisque \
                       scikit-image
+          pip install --upgrade scipy
       - name: Test with pytest
         run: |
           pytest -x --cov=./piq --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torch>=1.2.0,!=1.5.0
 torchvision>=0.4.0,!=0.6.0
-scipy==1.3.3
+scipy>=1.3.3
 gudhi>=3.2


### PR DESCRIPTION
Closes #157 

## Proposed Changes
- make `scipy` requirement less strict
- force testing CI to use latest available `scipy`

As a result, overall time was reduced to around 10 min, while tests take less than 4 min.

@zakajd @snk4tr ready for review