### PR TITLE
bug/gmsd: Add `alpha` parameter from the paper

### DIFF
--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -30,15 +30,17 @@ def get_meshgrid(size: Tuple[int, int]) -> torch.Tensor:
     return torch.meshgrid(x, y)
 
 
-def similarity_map(map_x: torch.Tensor, map_y: torch.Tensor, constant: float) -> torch.Tensor:
+def similarity_map(map_x: torch.Tensor, map_y: torch.Tensor, constant: float, alpha: float = 0.0) -> torch.Tensor:
     r""" Compute similarity_map between two tensors using Dice-like equation.
 
     Args:
         map_x: Tensor with map to be compared
         map_y: Tensor with map to be compared
         constant: Used for numerical stability
+        alpha: Masking coefficient. Substracts - `alpha` * map_x * map_y from denominator and nominator
     """
-    return (2.0 * map_x * map_y + constant) / (map_x ** 2 + map_y ** 2 + constant)
+    return (2.0 * map_x * map_y - alpha * map_x * map_y + constant) / \
+           (map_x ** 2 + map_y ** 2 - alpha * map_x * map_y + constant)
 
 
 def gradient_map(x: torch.Tensor, kernels: torch.Tensor) -> torch.Tensor:

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -149,7 +149,7 @@ def multi_scale_gmsd(prediction: torch.Tensor, target: torch.Tensor, data_range:
                      reduction: str = 'mean',
                      scale_weights: Optional[Union[torch.Tensor, Tuple[float, ...], List[float]]] = None,
                      chromatic: bool = False, alpha: float = 0.5, beta1: float = 0.01, beta2: float = 0.32,
-                     beta3: float = 15., t: float = 170 / (255 ** 2)) -> torch.Tensor:
+                     beta3: float = 15., t: float = 170) -> torch.Tensor:
     r"""Computation of Multi scale GMSD.
 
     Args:
@@ -193,8 +193,8 @@ def multi_scale_gmsd(prediction: torch.Tensor, target: torch.Tensor, data_range:
     if prediction.size(-1) < min_size or prediction.size(-2) < min_size:
         raise ValueError(f'Invalid size of the input images, expected at least {min_size}x{min_size}.')
 
-    prediction = prediction / float(data_range)
-    target = target / float(data_range)
+    prediction = prediction * 255 / float(data_range)
+    target = target * 255 / float(data_range)
 
     num_channels = prediction.size(1)
     if num_channels == 3:

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -69,7 +69,8 @@ def gmsd(prediction: torch.Tensor, target: torch.Tensor, reduction: Optional[str
             }[reduction](dim=0)
 
 
-def _gmsd(prediction: torch.Tensor, target: torch.Tensor, t: float = 170 / (255. ** 2), alpha: float = 0.0) -> torch.Tensor:
+def _gmsd(prediction: torch.Tensor, target: torch.Tensor,
+          t: float = 170 / (255. ** 2), alpha: float = 0.0) -> torch.Tensor:
     r"""Compute Gradient Magnitude Similarity Deviation
     Both inputs supposed to be in range [0, 1] with RGB order.
     Args:

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -149,7 +149,7 @@ def multi_scale_gmsd(prediction: torch.Tensor, target: torch.Tensor, data_range:
                      reduction: str = 'mean',
                      scale_weights: Optional[Union[torch.Tensor, Tuple[float, ...], List[float]]] = None,
                      chromatic: bool = False, alpha: float = 0.5, beta1: float = 0.01, beta2: float = 0.32,
-                     beta3: float = 15., t: float = 170 / (255. ** 2)) -> torch.Tensor:
+                     beta3: float = 15., t: float = 170) -> torch.Tensor:
     r"""Computation of Multi scale GMSD.
 
     Args:
@@ -193,8 +193,8 @@ def multi_scale_gmsd(prediction: torch.Tensor, target: torch.Tensor, data_range:
     if prediction.size(-1) < min_size or prediction.size(-2) < min_size:
         raise ValueError(f'Invalid size of the input images, expected at least {min_size}x{min_size}.')
 
-    prediction = prediction / float(data_range)
-    target = target / float(data_range)
+    prediction = prediction * 255.0 / float(data_range)
+    target = target * 255.0 / float(data_range)
 
     num_channels = prediction.size(1)
     if num_channels == 3:

--- a/tests/test_gmsd.py
+++ b/tests/test_gmsd.py
@@ -153,8 +153,8 @@ def test_multi_scale_gmsd_zero_for_equal_tensors(prediction: torch.Tensor, devic
 
 def test_multi_scale_gmsd_supports_different_data_ranges(prediction: torch.Tensor, target: torch.Tensor,
                                                          device: str) -> None:
-    prediction_255 = (prediction * 255).type(torch.uint8)
-    target_255 = (target * 255).type(torch.uint8)
+    prediction_255 = prediction * 255
+    target_255 = target * 255
 
     measure = multi_scale_gmsd(prediction.to(device), target.to(device))
     measure_255 = multi_scale_gmsd(prediction_255.to(device), target_255.to(device), data_range=255)
@@ -214,8 +214,8 @@ def test_multi_scale_gmsd_loss_zero_for_equal_tensors(prediction: torch.Tensor, 
 
 def test_multi_scale_gmsd_loss_supports_different_data_ranges(prediction: torch.Tensor, target: torch.Tensor,
                                                               device: str) -> None:
-    prediction_255 = (prediction * 255).type(torch.uint8)
-    target_255 = (target * 255).type(torch.uint8)
+    prediction_255 = prediction * 255
+    target_255 = target * 255
     loss = MultiScaleGMSDLoss()
     measure = loss(prediction.to(device), target.to(device))
     loss_255 = MultiScaleGMSDLoss(data_range=255)


### PR DESCRIPTION
Partially closes #161 

## Proposed Changes

  - After comparing current implementation with original paper I found missing `alpha` term in gradient similarity maps computation. Adding it slightly increases overall performance for both MS-GMSD and MS-GMSDc, but it's still far from values in the paper
  - Paper makes no reference about range of image values used in computations. After changing input range from 1.0 to 255.0 performance dropped by ~30%, so I assume that values should be in [0, 1]
  - There is also no reference about constant value in similarity maps computation. Currently we are using `0.0026` as in original GMSD paper. It's unlikely that it's so important for the final result.