### PR TITLE
Unify tensors description.

### DIFF
--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -24,10 +24,10 @@ def brisque(x: torch.Tensor,
     r"""Interface of BRISQUE index.
 
     Args:
-        x: Batch of images. Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W), channels first.
+        x: Tensor with shape (H, W), (C, H, W) or (N, C, H, W). RGB channel order for colour images.
         kernel_size: The side-length of the sliding window used in comparison. Must be an odd value.
         kernel_sigma: Sigma of normal distribution.
-        data_range: Value range of input images (usually 1.0 or 255).
+        data_range: Maximum value range of input images (usually 1.0 or 255).
         reduction: Reduction over samples in batch: "mean"|"sum"|"none".
         interpolation: Interpolation to be used for scaling.
 
@@ -75,7 +75,7 @@ def brisque(x: torch.Tensor,
 
 class BRISQUELoss(_Loss):
     r"""Creates a criterion that measures the BRISQUE score for input :math:`x`.
-    :math:`x` is tensor of 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W), channels first.
+    :math:`x` is tensor of 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W).
     The sum operation still operates over all the elements, and divides by :math:`n`.
     The division by :math:`n` can be avoided by setting ``reduction = 'sum'``.
 
@@ -93,7 +93,7 @@ class BRISQUELoss(_Loss):
         interpolation: Interpolation to be used for scaling.
 
     Shape:
-        - Input: Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W), channels first.
+        - Input: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
 
     Examples::
         >>> loss = BRISQUELoss()
@@ -183,7 +183,7 @@ def _aggd_parameters(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch
 
 
 def _natural_scene_statistics(luma: torch.Tensor, kernel_size: int = 7, sigma: float = 7. / 6) -> torch.Tensor:
-    kernel = gaussian_filter(size=kernel_size, sigma=sigma).view(1, 1, kernel_size, kernel_size).to(luma)
+    kernel = gaussian_filter(kernel_size=kernel_size, sigma=sigma).view(1, 1, kernel_size, kernel_size).to(luma)
     C = 1
     mu = F.conv2d(luma, kernel, padding=kernel_size // 2)
     mu_sq = mu ** 2

--- a/piq/feature_extractors/fid_inception.py
+++ b/piq/feature_extractors/fid_inception.py
@@ -131,17 +131,19 @@ class InceptionV3(nn.Module):
         for param in self.parameters():
             param.requires_grad = requires_grad
 
-    def forward(self, inp: torch.autograd.Variable) -> List[torch.autograd.Variable]:
+    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""Get Inception feature maps
 
         Args:
-            inp: Input tensor of shape Bx3xHxW. Values are expected to be in range (0, 1).
+            x: Batch of images with shape (N, 3, H, W). RGB colour order.
+                Values are expected to be in range (0, 1).
 
         Returns:
             List of torch.autograd.Variable, corresponding to the selected output block, sorted ascending by index.
         """
         outp = []
-        x = inp
+        assert (x.min() >= 0) and (x.max() <= 1), \
+            "Input tensor should be normalized in (0, 1) range."
 
         if self.resize_input:
             x = F.interpolate(x,

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -47,10 +47,10 @@ def gradient_map(x: torch.Tensor, kernels: torch.Tensor) -> torch.Tensor:
     r""" Compute gradient map for a given tensor and stack of kernels.
 
     Args:
-        x: Tensor with shape B x C x H x W
-        kernels: Stack of tensors for gradient computation with shape N x k_W x k_H
+        x: Tensor with shape (N, C, H, W).
+        kernels: Stack of tensors for gradient computation with shape (k_N, k_H, k_W)
     Returns:
-        Gradients of x per-channel with shape B x C x H x W
+        Gradients of x per-channel with shape (N, C, H, W)
     """
     padding = kernels.size(-1) // 2
     grads = torch.nn.functional.conv2d(x, kernels.to(x), padding=padding)
@@ -65,10 +65,10 @@ def pow_for_complex(base: torch.Tensor, exp: Union[int, float]) -> torch.Tensor:
     It will likely to be redundant with introduction of torch.ComplexTensor.
 
     Args:
-        base: Tensor with shape (B x C x H x W) or (B x C x H x W x 2)
+        base: Tensor with shape (N, C, H, W) or (N, C, H, W, 2).
         exp: Exponent
     Returns:
-        Complex tensor with shape (B x C x H x W x 2)
+        Complex tensor with shape (N, C, H, W, 2).
     """
     if base.dim() == 4:
         x_complex_r = base.abs()

--- a/piq/functional/colour_conversion.py
+++ b/piq/functional/colour_conversion.py
@@ -7,10 +7,10 @@ def rgb2lmn(x: torch.Tensor) -> torch.Tensor:
     r"""Convert a batch of RGB images to a batch of LMN images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in RGB colour space.
+        x: Batch of images with shape (N, 3, H, W). RGB colour space.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in LMN colour space.
+        Batch of images with shape (N, 3, H, W). LMN colour space.
     """
     weights_rgb_to_lmn = torch.tensor([[0.06, 0.63, 0.27],
                                        [0.30, 0.04, -0.35],
@@ -23,10 +23,10 @@ def rgb2xyz(x: torch.Tensor) -> torch.Tensor:
     r"""Convert a batch of RGB images to a batch of XYZ images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in RGB colour space.
+        x: Batch of images with shape (N, 3, H, W). RGB colour space.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in XYZ colour space.
+        Batch of images with shape (N, 3, H, W). XYZ colour space.
     """
     mask_below = (x <= 0.04045).to(x)
     mask_above = (x > 0.04045).to(x)
@@ -45,12 +45,12 @@ def xyz2lab(x: torch.Tensor, illuminant: str = 'D50', observer: str = '2') -> to
     r"""Convert a batch of XYZ images to a batch of LAB images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in XYZ colour space.
+        x: Batch of images with shape (N, 3, H, W). XYZ colour space.
         illuminant: {“A”, “D50”, “D55”, “D65”, “D75”, “E”}, optional. The name of the illuminant.
         observer: {“2”, “10”}, optional. The aperture angle of the observer.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in LAB colour space.
+        Batch of images with shape (N, 3, H, W). LAB colour space.
     """
     epsilon = 0.008856
     kappa = 903.3
@@ -89,11 +89,11 @@ def rgb2lab(x: torch.Tensor, data_range: Union[int, float] = 255) -> torch.Tenso
     r"""Convert a batch of RGB images to a batch of LAB images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in RGB colour space.
+        x: Batch of images with shape (N, 3, H, W). RGB colour space.
         data_range: dynamic range of the input image.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in LAB colour space.
+        Batch of images with shape (N, 3, H, W). LAB colour space.
     """
     return xyz2lab(rgb2xyz(x / float(data_range)))
 
@@ -102,10 +102,10 @@ def rgb2yiq(x: torch.Tensor) -> torch.Tensor:
     r"""Convert a batch of RGB images to a batch of YIQ images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in RGB colour space.
+        x: Batch of images with shape (N, 3, H, W). RGB colour space.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in YIQ colour space.
+        Batch of images with shape (N, 3, H, W). YIQ colour space.
     """
     yiq_weights = torch.tensor([
         [0.299, 0.587, 0.114],
@@ -119,10 +119,10 @@ def rgb2lhm(x: torch.Tensor) -> torch.Tensor:
     r"""Convert a batch of RGB images to a batch of LHM images
 
     Args:
-        x: Batch of 4D (N x 3 x H x W) images in RGB colour space.
+        x: Batch of images with shape (N, 3, H, W). RGB colour space.
 
     Returns:
-        Batch of 4D (N x 3 x H x W) images in LHM colour space.
+        Batch of images with shape (N, 3, H, W). LHM colour space.
 
     Reference:
         https://arxiv.org/pdf/1608.07433.pdf

--- a/piq/functional/filters.py
+++ b/piq/functional/filters.py
@@ -5,7 +5,8 @@ import torch
 def haar_filter(kernel_size: int) -> torch.Tensor:
     r"""Creates Haar kernel
     Returns:
-        kernel: Tensor with shape 1 x `kernel_size` x `kernel_size`"""
+        kernel: Tensor with shape (1, kernel_size, kernel_size)
+    """
     kernel = torch.ones((kernel_size, kernel_size)) / kernel_size
     kernel[kernel_size // 2:, :] = - kernel[kernel_size // 2:, :]
     return kernel.unsqueeze(0)
@@ -14,7 +15,8 @@ def haar_filter(kernel_size: int) -> torch.Tensor:
 def hann_filter(kernel_size: int) -> torch.Tensor:
     r"""Creates  Hann kernel
     Returns:
-        kernel: Tensor with shape 1 x `kernel_size` x `kernel_size`"""
+        kernel: Tensor with shape (1, kernel_size, kernel_size)
+    """
     # Take bigger window and drop borders
     window = torch.hann_window(kernel_size + 2, periodic=False)[1:-1]
     kernel = window[:, None] * window[None, :]
@@ -22,16 +24,16 @@ def hann_filter(kernel_size: int) -> torch.Tensor:
     return kernel.view(1, kernel_size, kernel_size) / kernel.sum()
 
 
-def gaussian_filter(size: int, sigma: float) -> torch.Tensor:
+def gaussian_filter(kernel_size: int, sigma: float) -> torch.Tensor:
     r"""Returns 2D Gaussian kernel N(0,`sigma`^2)
     Args:
-        size: Size of the lernel
+        size: Size of the kernel
         sigma: Std of the distribution
     Returns:
-        gaussian_kernel: 2D kernel with shape (1 x kernel_size x kernel_size)
+        gaussian_kernel: Tensor with shape (1, kernel_size, kernel_size)
     """
-    coords = torch.arange(size).to(dtype=torch.float32)
-    coords -= (size - 1) / 2.
+    coords = torch.arange(kernel_size).to(dtype=torch.float32)
+    coords -= (kernel_size - 1) / 2.
 
     g = coords ** 2
     g = (- (g.unsqueeze(0) + g.unsqueeze(1)) / (2 * sigma ** 2)).exp()
@@ -44,12 +46,13 @@ def gaussian_filter(size: int, sigma: float) -> torch.Tensor:
 def scharr_filter() -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Scharr kernel in X direction
     Returns:
-        kernel: Tensor with shape 1x3x3"""
+        kernel: Tensor with shape (1, 3, 3)
+    """
     return torch.tensor([[[-3., 0., 3.], [-10., 0., 10.], [-3., 0., 3.]]]) / 16
 
 
 def prewitt_filter() -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Prewitt kernel in X direction
     Returns:
-        kernel: Tensor with shape 1x3x3"""
+        kernel: Tensor with shape (1, 3, 3)"""
     return torch.tensor([[[-1., 0., 1.], [-1., 0., 1.], [-1., 0., 1.]]]) / 3

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -21,10 +21,11 @@ from piq.functional import similarity_map, gradient_map, prewitt_filter, rgb2yiq
 def gmsd(prediction: torch.Tensor, target: torch.Tensor, reduction: Optional[str] = 'mean',
          data_range: Union[int, float] = 1., t: float = 170 / (255. ** 2)) -> torch.Tensor:
     r"""Compute Gradient Magnitude Similarity Deviation
-    Both inputs supposed to be in range [0, 1] with RGB order.
+    Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
+
     Args:
-        prediction: Tensor of shape :math:`(N, C, H, W)` holding an distorted image.
-        target: Tensor of shape :math:`(N, C, H, W)` holding an target image
+        prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         reduction: Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
             ``'mean'``: the sum of the output will be divided by the number of
@@ -72,10 +73,10 @@ def gmsd(prediction: torch.Tensor, target: torch.Tensor, reduction: Optional[str
 def _gmsd(prediction: torch.Tensor, target: torch.Tensor,
           t: float = 170 / (255. ** 2), alpha: float = 0.0) -> torch.Tensor:
     r"""Compute Gradient Magnitude Similarity Deviation
-    Both inputs supposed to be in range [0, 1] with RGB order.
+    Both inputs supposed to be in range [0, 1] with RGB channels order.
     Args:
-        prediction: Tensor of shape :math:`(N, 1, H, W)` holding an distorted grayscale image.
-        target: Tensor of shape :math:`(N, 1, H, W)` holding an target grayscale image
+        prediction: Tensor with shape (N, 1, H, W).
+        target: Tensor with shape (N, 1, H, W).
         t: Constant from the reference paper numerical stability of similarity map
         alpha: Masking coefficient for similarity masks computation
 
@@ -132,10 +133,11 @@ class GMSDLoss(_Loss):
 
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         r"""Computation of Gradient Magnitude Similarity Deviation (GMSD) as a loss function.
+        Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
 
         Args:
-            prediction: Tensor of prediction of the network.
-            target: Reference tensor.
+            prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+            target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
 
         Returns:
             Value of GMSD loss to be minimized. 0 <= GMSD loss <= 1.
@@ -151,10 +153,12 @@ def multi_scale_gmsd(prediction: torch.Tensor, target: torch.Tensor, data_range:
                      chromatic: bool = False, alpha: float = 0.5, beta1: float = 0.01, beta2: float = 0.32,
                      beta3: float = 15., t: float = 170) -> torch.Tensor:
     r"""Computation of Multi scale GMSD.
+    Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
+    The height and width should be at least 2 ** scales + 1.
 
     Args:
-        prediction: Tensor of prediction of the network. The height and width should be at least 2 ** scales + 1.
-        target: Reference tensor. The height and width should be at least 2 ** scales + 1.
+        prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: The difference between the maximum and minimum of the pixel value,
             i.e., if for image x it holds min(x) = 0 and max(x) = 1, then data_range = 1.
             The pixel value interval of both input and output should remain the same.
@@ -294,12 +298,12 @@ class MultiScaleGMSDLoss(_Loss):
             
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         r"""Computation of Multi Scale GMSD index as a loss function.
+        Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
+        The height and width should be at least 2 ** scales + 1.
 
         Args:
-            prediction: Tensor of prediction of the network. Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W),
-            channels first. The height and width should be at least 2 ** scales + 1.
-            target: Reference tensor. Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W), channels first.
-            The height and width should be at least 2 ** scales + 1.
+            prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+            target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
 
         Returns:
             Value of MS-GMSD loss to be minimized. 0 <= MS-GMSD loss <= 1.

--- a/piq/gs.py
+++ b/piq/gs.py
@@ -67,10 +67,10 @@ def relative(intervals: np.ndarray, alpha_max: float, i_max: int = 100) -> np.nd
 def lmrk_table(witnesses: np.ndarray, landmarks: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     r"""Construct an input for the gudhi.WitnessComplex function.
     Args:
-        witnesses: Array of size w x d, containing witnesses
-        landmarks: Array of size l x d, containing landmarks
+        witnesses: Array with shape (w, d), containing witnesses.
+        landmarks: Array with shape (l, d), containing landmarks.
     Returns:
-        distances: 3D array of size w x l x 2. It satisfies the property that
+        distances: 3D array with shape (w, l, 2). It satisfies the property that
             distances[i, :, :] is [idx_i, dists_i], where dists_i are the sorted distances
             from the i-th witness to each point in L and idx_i are the indices of the corresponding points
             in L, e.g., D[i, :, :] = [[0, 0.1], [1, 0.2], [3, 0.3], [2, 0.4]]
@@ -90,7 +90,7 @@ def witness(
     """Compute the persistence intervals for the dataset of features using the witness complex.
 
     Args:
-        features: Array of shape (N_samples, data_dim) representing the dataset.
+        features: Array with shape (N_samples, data_dim) representing the dataset.
         sample_size: Number of landmarks to use on each iteration.
         gamma: Parameter determining maximum persistence value. Default is `1.0 / 128 * N_imgs / 5000`
 
@@ -136,13 +136,13 @@ class GS(BaseFeatureMetric):
     But dimensionalities should match, otherwise it won't be possible to correctly compute statistics.
 
     Args:
-        predicted_features (torch.Tensor): Low-dimension representation of predicted image set.
+        predicted_features: Low-dimension representation of predicted image set.
             Shape (N_pred, encoder_dim)
-        target_features (torch.Tensor): Low-dimension representation of target image set.
+        target_features: Low-dimension representation of target image set.
             Shape (N_targ, encoder_dim)
 
     Returns:
-        score (torch.Tensor): Scalar value of the distance between image sets.
+        score: Scalar value of the distance between image sets.
 
     References:
         .. [1] Khrulkov V., Oseledets I. (2018).

--- a/piq/haarpsi.py
+++ b/piq/haarpsi.py
@@ -23,10 +23,10 @@ def haarpsi(x: torch.Tensor, y: torch.Tensor, reduction: Optional[str] = 'mean',
             data_range: Union[int, float] = 1., scales: int = 3, subsample: bool = True,
             c: float = 30.0, alpha: float = 4.2) -> torch.Tensor:
     r"""Compute Haar Wavelet-Based Perceptual Similarity
-    Input can by greyscale tensor of colour image with RGB channels order.
+    Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
     Args:
-        x: Tensor of shape :math:`(N, C, H, W)` holding an distorted image.
-        y: Tensor of shape :math:`(N, C, H, W)` holding an target image
+        x: Tensor with shape (H, W), (C, H, W) or (N, C, H, W) holding a distorted image.
+        y: Tensor with shape (H, W), (C, H, W) or (N, C, H, W) holding a target image.
         reduction: Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
             ``'mean'``: the sum of the output will be divided by the number of
@@ -99,12 +99,12 @@ def haarpsi(x: torch.Tensor, y: torch.Tensor, reduction: Optional[str] = 'mean',
         coefficients_x.append(coeff_x)
         coefficients_y.append(coeff_y)
 
-    # Shape [B x {scales * 2} x H x W]
+    # Shape (N, {scales * 2}, H, W)
     coefficients_x = torch.cat(coefficients_x, dim=1)
     coefficients_y = torch.cat(coefficients_y, dim=1)
 
     # Low-frequency coefficients used as weights
-    # Shape [B x 2 x H x W]
+    # Shape (N, 2, H, W)
     weights = torch.max(torch.abs(coefficients_x[:, 4:]), torch.abs(coefficients_y[:, 4:]))
     
     # High-frequency coefficients used for similarity computation in 2 orientations (horizontal and vertical)
@@ -148,7 +148,6 @@ class HaarPSILoss(_Loss):
     each element in the input and target.
 
     The sum operation still operates over all the elements, and divides by :math:`n`.
-
     The division by :math:`n` can be avoided if one sets ``reduction = 'sum'``.
 
     Args:
@@ -165,8 +164,8 @@ class HaarPSILoss(_Loss):
         alpha: Exponent used for similarity maps weightning. See [1] for details
 
     Shape:
-        - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
-        - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+        - Input:Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
+        - Target: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
 
     Examples::
 

--- a/piq/haarpsi.py
+++ b/piq/haarpsi.py
@@ -164,7 +164,7 @@ class HaarPSILoss(_Loss):
         alpha: Exponent used for similarity maps weightning. See [1] for details
 
     Shape:
-        - Input:Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
+        - Input: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
         - Target: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
 
     Examples::

--- a/piq/isc.py
+++ b/piq/isc.py
@@ -58,10 +58,10 @@ class IS(BaseFeatureMetric):
     IS is computed separatly for predicted and target features and expects raw InceptionV3 model logits as inputs.
 
     Args:
-        predicted_features (torch.Tensor): Low-dimension representation of predicted image set.
-            Required to have shape (N_pred, encoder_dim)
-        target_features (torch.Tensor): Low-dimension representation of target image set.
-            Required to have shape (N_targ, encoder_dim)
+        predicted_features: Low-dimension representation of predicted image set.
+            Shape (N_pred, encoder_dim).
+        target_features: Low-dimension representation of target image set.
+            Shape (N_targ, encoder_dim).
 
     Returns:
         distance(predicted_score, target_score): L1 or L2 distance between scores.

--- a/piq/kid.py
+++ b/piq/kid.py
@@ -12,21 +12,22 @@ def _polynomial_kernel(
         gamma: Optional[float] = None,
         coef0: float = 1.) -> torch.Tensor:
     """
-        Compute the polynomial kernel between x and y::
-            K(X, Y) = (gamma <X, Y> + coef0)^degree
-        Source: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.polynomial_kernel.html
-        Parameters
-        ----------
-        X : torch.Tensor of shape (n_samples_1, n_features)
-        Y : torch.Tensor of shape (n_samples_2, n_features)
-        degree : int, default 3
-        gamma : float, default None
-            if None, defaults to 1.0 / n_features
-        coef0 : float, default 1
-        Returns
-        -------
-        Gram matrix : array of shape (n_samples_1, n_samples_2)
-        """
+    Compute the polynomial kernel between x and y
+    K(X, Y) = (gamma <X, Y> + coef0)^degree
+
+    Args:
+        X: Tensor with hape (n_samples_1, n_features)
+        Y: torch.Tensor of shape (n_samples_2, n_features)
+        degree: default 3
+        gamma: if None, defaults to 1.0 / n_features.
+        coef0 : default 1
+
+    Returns:
+        Gram matrix : Array with shape (n_samples_1, n_samples_2)
+
+    Reference:
+        https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.polynomial_kernel.html
+    """
 
     if Y is None:
         Y = X
@@ -151,12 +152,12 @@ class KID(BaseFeatureMetric):
     But dimensionalities should match, otherwise it won't be possible to correctly compute statistics.
 
     Args:
-        predicted_features(torch.Tensor): Low-dimension representation of predicted image set.
+        predicted_features: Low-dimension representation of predicted image set.
             Shape (N_pred, encoder_dim)
-        target_features(torch.Tensor): Low-dimension representation of target image set. Shape (N_targ, encoder_dim)
+        target_features: Low-dimension representation of target image set. Shape (N_targ, encoder_dim)
 
     Returns:
-        score(torch.Tensor): Scalar value of the distance between image sets features.
+        score: Scalar value of the distance between image sets features.
         variance(Optional[torch.Tensor]): If `ret_var` is True, also returns variance
 
     Reference:
@@ -212,9 +213,9 @@ class KID(BaseFeatureMetric):
 
         Args:
             predicted_features: Samples from data distribution.
-                Shape (N_samples, data_dim), dtype: torch.float32 in range 0 - 1.
+                Shape (N_samples, data_dim), dtype: torch.float32 in range [0, 1].
             target_features: Samples from data distribution.
-                Shape (N_samples, data_dim), dtype: torch.float32 in range 0 - 1
+                Shape (N_samples, data_dim), dtype: torch.float32 in range [0, 1].
 
         Returns:
             KID score and variance (optional).

--- a/piq/kid.py
+++ b/piq/kid.py
@@ -16,7 +16,7 @@ def _polynomial_kernel(
     K(X, Y) = (gamma <X, Y> + coef0)^degree
 
     Args:
-        X: Tensor with hape (n_samples_1, n_features)
+        X: Tensor with shape (n_samples_1, n_features)
         Y: torch.Tensor of shape (n_samples_2, n_features)
         degree: default 3
         gamma: if None, defaults to 1.0 / n_features.

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -21,14 +21,12 @@ def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, 
     r"""Compute Mean Deviation Similarity Index (MDSI) for a batch of images.
 
     Note:
-        Both inputs are supposed to have RGB order in accordance with the original approach.
-        Nevertheless, the method supports greyscale images, which are converted to RGB by copying the grey
-        channel 3 times.
+        Both inputs are supposed to have RGB channels order.
+        Greyscale images converted to RGB by copying the grey channel 3 times.
 
     Args:
-        prediction: Batch of predicted (distorted) images. Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W),
-        channels first.
-        target: Batch of target (reference) images. Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+        prediction: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
+        target: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         c1: coefficient to calculate gradient similarity. Default: 140.
@@ -136,7 +134,7 @@ class MDSILoss(_Loss):
         - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
         - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
 
-        Both inputs are supposed to have RGB order in accordance with the original approach.
+        Both inputs are supposed to have RGB channels order in accordance with the original approach.
         Nevertheless, the method supports greyscale images, which they are converted to RGB
         by copying the grey channel 3 times.
 
@@ -169,17 +167,18 @@ class MDSILoss(_Loss):
 
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         r"""Computation of Mean Deviation Similarity Index (MDSI) as a loss function.
+        Both inputs are supposed to have RGB channels order.
+        Greyscale images converted to RGB by copying the grey channel 3 times.
 
         Args:
-            prediction: Tensor of prediction of the network. Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W),
-            channels first.
-            target: Reference tensor. Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+            prediction: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
+            target: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
 
         Returns:
             Value of MDSI loss to be minimized. 0 <= MDSI loss <= 1.
 
         Note:
-            Both inputs are supposed to have RGB order in accordance with the original approach.
+            Both inputs are supposed to have RGB channels order in accordance with the original approach.
             Nevertheless, the method supports greyscale images, which are converted to RGB by copying the grey
             channel 3 times.
         """

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -25,8 +25,8 @@ def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, 
         Greyscale images converted to RGB by copying the grey channel 3 times.
 
     Args:
-        prediction: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
-        target: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
+        prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        target:Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         c1: coefficient to calculate gradient similarity. Default: 140.
@@ -131,8 +131,8 @@ class MDSILoss(_Loss):
         o: the power pooling applied on the final value of the deviation
 
     Shape:
-        - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
-        - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+        - Input: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
+        - Target: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
 
         Both inputs are supposed to have RGB channels order in accordance with the original approach.
         Nevertheless, the method supports greyscale images, which they are converted to RGB

--- a/piq/msid.py
+++ b/piq/msid.py
@@ -62,8 +62,8 @@ def _lanczos_m(A: np.ndarray, m: int, nv: int, rademacher: bool, starting_vector
         starting_vectors: Specified starting vectors.
 
     Returns:
-        T: A nv x m x m tensor, T[i, :, :] is the ith symmetric tridiagonal matrix.
-        V: A n x m x nv tensor, V[:, :, i] is the ith matrix with orthogonal rows.
+        T: Array with shape (nv, m, m), where T[i, :, :] is the i-th symmetric tridiagonal matrix.
+        V: Array with shape (n, m, nv) where, V[:, :, i] is the i-th matrix with orthogonal rows.
     """
     orthtol = 1e-5
     if type(starting_vectors) != np.ndarray:

--- a/piq/perceptual.py
+++ b/piq/perceptual.py
@@ -176,7 +176,7 @@ class ContentLoss(_Loss):
     def get_features(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""
         Args:
-            x: torch.Tensor with shape (N, C, H, W)
+            x: Tensor with shape (N, C, H, W)
         
         Returns:
             features: List of features extracted from intermediate layers
@@ -228,7 +228,7 @@ class StyleLoss(ContentLoss):
     def gram_matrix(self, x: torch.Tensor) -> torch.Tensor:
         r"""Compute Gram matrix for batch of features.
         Args:
-            x: Tensor of shape BxCxHxW
+            x: Tensor with shape (N, C, H, W).
         """
         B, C, H, W = x.size()
         gram = []

--- a/piq/perceptual.py
+++ b/piq/perceptual.py
@@ -79,6 +79,7 @@ class ContentLoss(_Loss):
     image to image tasks.
     Uses pretrained VGG models from torchvision. Normalizes features before summation.
     Expects input to be in range [0, 1] or normalized with ImageNet statistics into range [-1, 1]
+
     Args:
         feature_extractor: Model to extract features or model name in {`vgg16`, `vgg19`}.
         layers: List of strings with layer names. Default: [`relu3_3`]
@@ -92,6 +93,7 @@ class ContentLoss(_Loss):
             If there is no need to normalize data, use [1., 1., 1.].
         normalize_features: If true, unit-normalize each feature in channel dimension before scaling
             and computing distance. See [2] for details.
+
     References:
         .. [1] Gatys, Leon and Ecker, Alexander and Bethge, Matthias
         (2016). A Neural Algorithm of Artistic Style}
@@ -147,8 +149,8 @@ class ContentLoss(_Loss):
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         r"""Computation of Content loss between feature representations of prediction and target tensors.
         Args:
-            prediction: Tensor of prediction of the network.
-            target: Reference tensor.
+            prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+            target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         """
         _validate_input(input_tensors=(prediction, target), allow_5d=False)
         prediction, target = _adjust_dimensions(input_tensors=(prediction, target))

--- a/piq/psnr.py
+++ b/piq/psnr.py
@@ -12,8 +12,8 @@ def psnr(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1.0,
     Supports both greyscale and color images with RGB channel order.
 
     Args:
-        x: Batch of predicted images with shape (batch_size x channels x H x W)
-        y: Batch of target images with shape  (batch_size x channels x H x W)
+        x: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
+        y: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         convert_to_greyscale: Convert RGB image to YCbCr format and computes PSNR

--- a/piq/ssim.py
+++ b/piq/ssim.py
@@ -20,10 +20,11 @@ def ssim(x: torch.Tensor, y: torch.Tensor, kernel_size: int = 11, kernel_sigma: 
          data_range: Union[int, float] = 1., reduction: str = 'mean', full: bool = False,
          k1: float = 0.01, k2: float = 0.03) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Interface of Structural Similarity (SSIM) index.
+    Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
 
     Args:
-        x: Batch of images. Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-        y: Batch of images. Required to be 2D (H, W), 3D (C,H,W) 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
+        x: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+        y: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
         kernel_size: The side-length of the sliding window used in comparison. Must be an odd value.
         kernel_sigma: Sigma of normal distribution.
         data_range: Value range of input images (usually 1.0 or 255).
@@ -113,8 +114,8 @@ class SSIMLoss(_Loss):
             The pixel value interval of both input and output should remain the same.
 
     Shape:
-        - Input: Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-        - Target: Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
+        - Input: 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+        - Target: 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
     Examples::
         >>> loss = SSIMLoss()
@@ -153,10 +154,8 @@ class SSIMLoss(_Loss):
         r"""Computation of Structural Similarity (SSIM) index as a loss function.
 
         Args:
-            prediction: Tensor of prediction of the network. Required to be
-                2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-            target: Reference tensor. Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2),
-                channels first.
+            prediction: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            target: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
         Returns:
             Value of SSIM loss to be minimized, i.e 1 - `ssim`. 0 <= SSIM loss <= 1. In case of 5D input tensors,
@@ -173,12 +172,12 @@ def multi_scale_ssim(x: torch.Tensor, y: torch.Tensor, kernel_size: int = 11, ke
                      scale_weights: Optional[Union[Tuple[float], List[float], torch.Tensor]] = None,
                      k1: float = 0.01, k2: float = 0.03) -> torch.Tensor:
     r""" Interface of Multi-scale Structural Similarity (MS-SSIM) index.
+    Inputs supposed to be in range [0, data_range] with RGB channels order for colour images.
+    The size of the image should be at least (kernel_size - 1) * 2 ** (levels - 1) + 1.
 
     Args:
-        x: Batch of images. Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-            The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
-        y: Batch of images. Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-            The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
+        x: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+        y: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
         kernel_size: The side-length of the sliding window used in comparison. Must be an odd value.
         kernel_sigma: Sigma of normal distribution.
         data_range: Value range of input images (usually 1.0 or 255).
@@ -262,10 +261,8 @@ class MultiScaleSSIMLoss(_Loss):
             \operatorname{sum}(1 - MSSIM),  &  \text{if reduction} = \text{'sum'.}
         \end{cases}
 
-    :math:`x` and :math:`y` are tensors of arbitrary shapes with a total
-    of :math:`n` elements each.
-    The sum operation still operates over all the elements, and divides by :math:`n`.
-    The division by :math:`n` can be avoided if one sets ``reduction = 'sum'``.
+    The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
+    For colour images channel order is RGB.
     In case of 5D input tensors, complex value is returned as a tensor of size 2.
 
     Args:
@@ -286,10 +283,8 @@ class MultiScaleSSIMLoss(_Loss):
             The pixel value interval of both input and output should remain the same.
 
     Shape:
-        - Input: Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-            The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
-        - Target: Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first.
-            The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
+        - Input: 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+        - Target: 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
     Examples::
         >>> loss = MultiScaleSSIMLoss()
@@ -334,13 +329,12 @@ class MultiScaleSSIMLoss(_Loss):
 
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         r"""Computation of Multi-scale Structural Similarity (MS-SSIM) index as a loss function.
+        The size of the image should be at least (kernel_size - 1) * 2 ** (levels - 1) + 1.
+        For colour images channel order is RGB.
 
         Args:
-            prediction: Tensor of prediction of the network. Required to be
-                2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2), channels first. The size of the image
-                should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
-            target: Reference tensor. Required to be 2D (H, W), 3D (C,H,W), 4D (N,C,H,W) or 5D (N,C,H,W,2),
-                channels first. The size of the image should be (kernel_size - 1) * 2 ** (levels - 1) + 1.
+            prediction: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            target: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
         Returns:
             Value of MS-SSIM loss to be minimized, i.e. 1-`ms_sim`. 0 <= MS-SSIM loss <= 1. In case of 5D tensor,
@@ -359,8 +353,8 @@ def _ssim_per_channel(x: torch.Tensor, y: torch.Tensor, kernel: torch.Tensor,
     r"""Calculate Structural Similarity (SSIM) index for X and Y per channel.
 
     Args:
-        x: Batch of images, (N,C,H,W).
-        y: Batch of images, (N,C,H,W).
+        x: Tensor with shape (N, C, H, W).
+        y: Tensor with shape (N, C, H, W).
         kernel: 2D Gaussian kernel.
         data_range: Value range of input images (usually 1.0 or 255).
         k1: Algorithm parameter, K1 (small constant, see [1]).
@@ -404,8 +398,8 @@ def _multi_scale_ssim(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, f
     r"""Calculates Multi scale Structural Similarity (MS-SSIM) index for X and Y.
 
     Args:
-        x: Batch of images, (N,C,H,W).
-        y: Batch of images, (N,C,H,W).
+        x: Tensor with shape (N, C, H, W).
+        y: Tensor with shape (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255).
         kernel: 2D Gaussian kernel.
         scale_weights_tensor: Weights for scaled SSIM
@@ -449,8 +443,8 @@ def _ssim_per_channel_complex(x: torch.Tensor, y: torch.Tensor, kernel: torch.Te
     r"""Calculate Structural Similarity (SSIM) index for Complex X and Y per channel.
 
     Args:
-        x: Batch of complex images, (N,C,H,W,2).
-        y: Batch of complex images, (N,C,H,W,2).
+        x: Complex tensor with shape (N, C, H, W, 2).
+        y: Complex tensor with shape (N, C, H, W, 2).
         kernel: 2-D gauss kernel.
         data_range: Value range of input images (usually 1.0 or 255).
         k1: Algorithm parameter, K1 (small constant, see [1]).
@@ -513,8 +507,8 @@ def _multi_scale_ssim_complex(x: torch.Tensor, y: torch.Tensor, data_range: Unio
     r"""Calculate Multi scale Structural Similarity (MS-SSIM) index for Complex X and Y.
 
     Args:
-        x: Batch of complex images, (N,C,H,W,2).
-        y: Batch of complex images, (N,C,H,W,2).
+        x: Complex tensor with shape (N, C, H, W, 2).
+        y: Complex tensor with shape (N, C, H, W, 2).
         data_range: Value range of input images (usually 1.0 or 255).
         kernel: 2-D gauss kernel.
         k1: Algorithm parameter, K1 (small constant, see [1]).

--- a/piq/tv.py
+++ b/piq/tv.py
@@ -11,7 +11,7 @@ def total_variation(x: torch.Tensor, reduction: str = 'mean', norm_type: str = '
     r"""Compute Total Variation metric
 
     Args:
-        x: Tensor of shape :math:`(N, C, H, W)` holding an input image.
+        x: Tensor with shape (N, C, H, W).
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         norm_type: {'l1', 'l2', 'l2_squared'}, defines which type of norm to implement, isotropic  or anisotropic.
 
@@ -74,7 +74,7 @@ class TVLoss(_Loss):
             ``'mean'``: the sum of the output will be divided by the number of
             elements in the output, ``'sum'``: the output will be summed. Default: ``'mean'``
     Shape:
-        - Input: Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W), channels first.
+        - Input: Required to be 2D (H, W), 3D (C,H,W) or 4D (N,C,H,W)
     Examples::
 
         >>> loss = TVLoss()

--- a/piq/utils/common.py
+++ b/piq/utils/common.py
@@ -3,7 +3,7 @@ import torch
 
 
 def _adjust_dimensions(input_tensors: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]):
-    r"""Expands input tensors dimensions to 4D
+    r"""Expands input tensors dimensions to 4D (N, C, H, W).
     """
     if isinstance(input_tensors, torch.Tensor):
         input_tensors = (input_tensors,)

--- a/piq/vif.py
+++ b/piq/vif.py
@@ -34,11 +34,11 @@ def vif_p(prediction: torch.Tensor, target: torch.Tensor, sigma_n_sq: float = 2.
           data_range: Union[int, float] = 1.0, reduction: str = 'mean') -> torch.Tensor:
     r"""Compute Visiual Information Fidelity in **pixel** domain for a batch of images.
     This metric isn't symmetric, so make sure to place arguments in correct order.
+    Both inputs supposed to have RGB channels order.
 
-    Both inputs supposed to have RGB order.
     Args:
-        prediction: Batch of predicted images with shape (batch_size x channels x H x W)
-        target: Batch of target images with shape  (batch_size x channels x H x W)
+        prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         sigma_n_sq: HVS model parameter (variance of the visual noise).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"

--- a/piq/vsi.py
+++ b/piq/vsi.py
@@ -25,8 +25,8 @@ def vsi(prediction: torch.Tensor, target: torch.Tensor, reduction: str = 'mean',
     channel 3 times.
 
     Args:
-        prediction: Batch of predicted images with shape (batch_size x channels x H x W)
-        target: Batch of target images with shape  (batch_size x channels x H x W)
+        prediction:  Tensor with shape (H, W), (C, H, W) or (N, C, H, W) holding a distorted image.
+        target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W) holding a target image.
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         c1: coefficient to calculate saliency component of VSI
@@ -43,8 +43,8 @@ def vsi(prediction: torch.Tensor, target: torch.Tensor, reduction: str = 'mean',
         VSI: Index of similarity between two images. Usually in [0, 1] interval.
 
     Shape:
-            - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
-            - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+        - Input:  Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
+        - Target: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
     Note:
         The original method supports only RGB image.
         See https://ieeexplore.ieee.org/document/6873260 for details.
@@ -141,8 +141,8 @@ class VSILoss(_Loss):
         sigma_c: coefficient to get SDSP
 
     Shape:
-        - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
-        - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
+        - Input: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
+        - Target: Required to be 2D (H, W), 3D (C, H, W) or 4D (N, C, H, W). RGB channel order for colour images.
 
         Both inputs are supposed to have RGB channels order in accordance with the original approach.
         Nevertheless, the method supports greyscale images, which they are converted to RGB

--- a/piq/vsi.py
+++ b/piq/vsi.py
@@ -20,7 +20,7 @@ def vsi(prediction: torch.Tensor, target: torch.Tensor, reduction: str = 'mean',
         omega_0: float = 0.021, sigma_f: float = 1.34, sigma_d: float = 145., sigma_c: float = 0.001) -> torch.Tensor:
     r"""Compute Visual Saliency-induced Index for a batch of images.
 
-    Both inputs are supposed to have RGB order in accordance with the original approach.
+    Both inputs are supposed to have RGB channels order in accordance with the original approach.
     Nevertheless, the method supports greyscale images, which they are converted to RGB by copying the grey
     channel 3 times.
 
@@ -144,7 +144,7 @@ class VSILoss(_Loss):
         - Input: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
         - Target: Required to be 2D (H,W), 3D (C,H,W), 4D (N,C,H,W), channels first.
 
-        Both inputs are supposed to have RGB order in accordance with the original approach.
+        Both inputs are supposed to have RGB channels order in accordance with the original approach.
         Nevertheless, the method supports greyscale images, which they are converted to RGB
         by copying the grey channel 3 times.
 
@@ -186,7 +186,7 @@ class VSILoss(_Loss):
             Value of VSI loss to be minimized. 0 <= VSI loss <= 1.
 
         Note:
-            Both inputs are supposed to have RGB order in accordance with the original approach.
+            Both inputs are supposed to have RGB channels order in accordance with the original approach.
             Nevertheless, the method supports greyscale images, which they are converted to RGB by copying the grey
             channel 3 times.
         """

--- a/tests/test_fid.py
+++ b/tests/test_fid.py
@@ -7,8 +7,8 @@ from piq.feature_extractors import InceptionV3
 
 class TestDataset(torch.utils.data.Dataset):
     def __init__(self):
-        self.data = torch.randn(15, 3, 256, 256)
-        self.mask = torch.randn(15, 3, 256, 256)
+        self.data = torch.rand(15, 3, 256, 256)
+        self.mask = torch.rand(15, 3, 256, 256)
 
     def __getitem__(self, index):
         x = self.data[index]

--- a/tests/test_msid.py
+++ b/tests/test_msid.py
@@ -7,8 +7,8 @@ from piq.feature_extractors import InceptionV3
 
 class TestDataset(torch.utils.data.Dataset):
     def __init__(self):
-        self.data = torch.randn(15, 3, 256, 256)
-        self.mask = torch.randn(15, 3, 256, 256)
+        self.data = torch.rand(15, 3, 256, 256)
+        self.mask = torch.rand(15, 3, 256, 256)
 
     def __getitem__(self, index):
         x = self.data[index]


### PR DESCRIPTION
Closes #149 

## Proposed Changes

  - Format for tensor shapes is `(N, C, H, W)`, like in PyTorch documentation.