### PR TITLE
Re-write README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
  
-# PyTorch Image Quality
+![piq_logo](https://user-images.githubusercontent.com/15848838/95228385-ed106500-0807-11eb-8584-d3fdbdd47ac7.jpeg)
+
 [![License][license-shield]][license-url]
 [![PyPI version][pypi-version-shield]][pypi-version-url]
 [![Conda version][conda-version-shield]][conda-version-url]  
@@ -25,10 +26,8 @@ Collection of measures and metrics for image quality assessment.
 <!-- GETTING STARTED -->
 ### Getting started  
 
-All metrics can be broadly categorized into 2 groups. First group takes image or images as input, e.g PSNR, SSIM, BRISQUE. 
-Second takes list of image features, pre-extracted by some feature extractor network, e.g. IS, FID, KID.
-
-For the first group we have functional interface, which returns metric value and class interface, which allows to use any metric as a loss.
+First group of metrics takes image or images as input, e.g PSNR, SSIM, BRISQUE. 
+We have functional interface, which returns metric value and class interface, which allows to use any metric as a loss.
 
 ```python
 import torch
@@ -44,7 +43,8 @@ output: torch.Tensor = loss(prediction, target)
 output.backward()
 ```
 
-For the second group you can extract image features using `_compute_feats` method of a class. Note, that `_compute_feats` consumes a data loader of predefined format.
+Second group takes a list of image features e.g. IS, FID, KID.
+Image features can be extracted by some feature extractor network separetely, or by using `_compute_feats` method of a class. Note, that `_compute_feats` consumes a dataloader of predefined format.
 
 ```python
 import torch
@@ -58,8 +58,7 @@ second_feats = fid_metric._compute_feats(second_dl)
 fid: torch.Tensor = fid_metric(first_feats, second_feats)
 ```
 
-If you already have image features, pre-extracted from feature extractor network,
-use class interface for score computation:
+If you already have image features, use class interface for score computation:
 
 ```python
 import torch
@@ -70,6 +69,8 @@ target_feats = torch.rand(10000, 1024)
 msid_metric = MSID()
 msid: torch.Tensor = msid_metric(prediction_feats, target_feats)
 ```
+
+For a full list of examples, see [image metrics](examples/image_metrics.py) and [feature metrics](examples/feature_metrics.py) examles.
 
 <!-- IMAGE METRICS -->
 ### Image metrics

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ output.backward()
 
 For the second group you can extract image features using `_compute_feats` method of a class. Note, that `_compute_feats` consumes a data loader of predefined format.
 
-```
+```python
 import torch
 from  torch.utils.data import DataLoader
 from piq import FID
@@ -61,7 +61,7 @@ fid: torch.Tensor = fid_metric(first_feats, second_feats)
 If you already have image features, pre-extracted from feature extractor network,
 use class interface for score computation:
 
-```
+```python
 import torch
 from piq import FID
 
@@ -71,10 +71,8 @@ msid_metric = MSID()
 msid: torch.Tensor = msid_metric(prediction_feats, target_feats)
 ```
 
-<!-- EXAMPLES -->
-### Examples
-
-Image metrics
+<!-- IMAGE METRICS -->
+### Image metrics
 
  1. [Blind/Referenceless Image Spatial Quality Evaluator (BRISQUE)](https://live.ece.utexas.edu/publications/2012/TIP%20BRISQUE.pdf)
  2. [Content score](https://openaccess.thecvf.com/content_cvpr_2016/html/Gatys_Image_Style_Transfer_CVPR_2016_paper.html)
@@ -91,39 +89,15 @@ Image metrics
  13. [Style score](https://openaccess.thecvf.com/content_cvpr_2016/html/Gatys_Image_Style_Transfer_CVPR_2016_paper.html)
  14. [Total Variation (TV)](https://en.wikipedia.org/wiki/Total_variation)
  15. [Visual Information Fidelity (VIF)](https://live.ece.utexas.edu/research/Quality/VIF.htm)
- 16. [Visual Saliency-induced Index (VSI) score](https://ieeexplore.ieee.org/document/6873260) 
+ 16. [Visual Saliency-induced Index (VSI)](https://ieeexplore.ieee.org/document/6873260) 
 
-Feature metrics
+<!-- FEATURE METRICS -->
+### Feature metrics
 1. [Frechet Inception Distance(FID)](https://arxiv.org/abs/1706.08500)
 2. [Geometry Score (GS)](https://arxiv.org/abs/1802.02664)
 3. [Inception Score(IS)](https://arxiv.org/abs/1606.03498)
-4. [Kernel Inception Distance(KID) score](https://arxiv.org/abs/1801.01401)
-5. [Multi-Scale Intrinsic Distance (MSID) score](https://arxiv.org/abs/1905.11141) 
-
-
- If image features are not available, extract them using `_compute_feats` of `FID` class. 
- Please note that `_compute_feats` consumes a data loader of predefined format.
- 
- Use `GS` class to compute [Geometry Score]() from image features, 
- pre-extracted from some feature extractor network. Computation is heavily CPU dependent, adjust `num_workers` parameter according to your system configuration:
- 
- GS metric requiers `gudhi` library which is not installed by default. 
- If you use conda, write: `conda install -c conda-forge gudhi`, otherwise follow [installation guide](http://gudhi.gforge.inria.fr/python/latest/installation.html).
- 
-
-
- <!-- IS EXAMPLES -->
- To compute difference between IS for 2 sets of image features, use `IS` class.
- ```python
- import torch
- from piq import IS
- 
- is_metric = IS(distance='l1') 
- prediction_feats = torch.rand(10000, 1024)
- target_feats = torch.rand(10000, 1024)
- distance: torch.Tensor = is_metric(prediction_feats, target_feats)
- ```  
-
+4. [Kernel Inception Distance(KID)](https://arxiv.org/abs/1801.01401)
+5. [Multi-Scale Intrinsic Distance (MSID)](https://arxiv.org/abs/1905.11141) 
 
 ### Overview
 

--- a/examples/feature_metrics.py
+++ b/examples/feature_metrics.py
@@ -4,8 +4,8 @@ import piq
 
 @torch.no_grad()
 def main():
-    prediction_features = torch.rand(10000, 512)
-    target_features = torch.rand(10000, 512)
+    prediction_features = torch.rand(2000, 128)
+    target_features = torch.rand(2000, 128)
 
     if torch.cuda.is_available():
         # Move to GPU to make computaions faster

--- a/examples/feature_metrics.py
+++ b/examples/feature_metrics.py
@@ -1,6 +1,5 @@
 import torch
 import piq
-from skimage.io import imread
 
 
 @torch.no_grad()
@@ -17,16 +16,16 @@ def main():
     fid: torch.Tensor = piq.FID()(prediction_features, target_features)
     print(f"FID: {fid:0.4f}")
 
-    # If image features are not available, extract them using _compute_feats of FID class. 
+    # If image features are not available, extract them using _compute_feats of FID class.
     # Please note that _compute_feats consumes a data loader of predefined format.
 
-    # Use GS class to compute Geometry Score from image features, pre-extracted from some feature extractor network. 
+    # Use GS class to compute Geometry Score from image features, pre-extracted from some feature extractor network.
     # Computation is heavily CPU dependent, adjust num_workers parameter according to your system configuration.
     gs: torch.Tensor = piq.GS(
         sample_size=64, num_iters=100, i_max=100, num_workers=4)(prediction_features, target_features)
     print(f"GS: {gs:0.4f}")
 
-    # Use inception_score function to compute IS from image features, pre-extracted from some feature extractor network. 
+    # Use inception_score function to compute IS from image features, pre-extracted from some feature extractor network.
     # Note, that we follow recomendations from paper "A Note on the Inception Score"
     isc_mean, _ = piq.inception_score(prediction_features, num_splits=10)
     # To compute difference between IS for 2 sets of image features, use IS class.
@@ -34,12 +33,13 @@ def main():
     print(f"IS: {isc_mean:0.4f}, difference: {isc:0.4f}")
 
     # Use KID class to compute KID score from image features, pre-extracted from some feature extractor network:
-    kid: torch.Tensor =  piq.KID()(prediction_features, target_features)
-    print(f"KID: {gs:0.4f}")
+    kid: torch.Tensor = piq.KID()(prediction_features, target_features)
+    print(f"KID: {kid:0.4f}")
 
     # Use MSID class to compute MSID score from image features, pre-extracted from some feature extractor network:
     msid: torch.Tensor = piq.MSID()(prediction_features, target_features)
-    print(f"MSID: {gs:0.4f}")
+    print(f"MSID: {msid:0.4f}")
+
 
 if __name__ == '__main__':
     main()

--- a/examples/feature_metrics.py
+++ b/examples/feature_metrics.py
@@ -1,0 +1,45 @@
+import torch
+import piq
+from skimage.io import imread
+
+
+@torch.no_grad()
+def main():
+    prediction_features = torch.rand(10000, 512)
+    target_features = torch.rand(10000, 512)
+
+    if torch.cuda.is_available():
+        # Move to GPU to make computaions faster
+        prediction_features = prediction_features.cuda()
+        target_features = target_features.cuda()
+
+    # Use FID class to compute FID score from image features, pre-extracted from some feature extractor network
+    fid: torch.Tensor = piq.FID()(prediction_features, target_features)
+    print(f"FID: {fid:0.4f}")
+
+    # If image features are not available, extract them using _compute_feats of FID class. 
+    # Please note that _compute_feats consumes a data loader of predefined format.
+
+    # Use GS class to compute Geometry Score from image features, pre-extracted from some feature extractor network. 
+    # Computation is heavily CPU dependent, adjust num_workers parameter according to your system configuration.
+    gs: torch.Tensor = piq.GS(
+        sample_size=64, num_iters=100, i_max=100, num_workers=4)(prediction_features, target_features)
+    print(f"GS: {gs:0.4f}")
+
+    # Use inception_score function to compute IS from image features, pre-extracted from some feature extractor network. 
+    # Note, that we follow recomendations from paper "A Note on the Inception Score"
+    isc_mean, _ = piq.inception_score(prediction_features, num_splits=10)
+    # To compute difference between IS for 2 sets of image features, use IS class.
+    isc: torch.Tensor = piq.IS(distance='l1')(prediction_features, target_features)
+    print(f"IS: {isc_mean:0.4f}, difference: {isc:0.4f}")
+
+    # Use KID class to compute KID score from image features, pre-extracted from some feature extractor network:
+    kid: torch.Tensor =  piq.KID()(prediction_features, target_features)
+    print(f"KID: {gs:0.4f}")
+
+    # Use MSID class to compute MSID score from image features, pre-extracted from some feature extractor network:
+    msid: torch.Tensor = piq.MSID()(prediction_features, target_features)
+    print(f"MSID: {gs:0.4f}")
+
+if __name__ == '__main__':
+    main()

--- a/examples/image_metrics.py
+++ b/examples/image_metrics.py
@@ -1,0 +1,125 @@
+import torch
+import piq
+from skimage.io import imread
+
+
+@torch.no_grad()
+def main():
+    # Read RGB image and it's noisy version
+    prediction = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1) / 255.
+    target = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1) / 255.
+    
+    if torch.cuda.is_available():
+        # Move to GPU to make computaions faster
+        prediction = prediction.cuda()
+        target = target.cuda()
+
+    # To compute BRISQUE score as a measure, use lower case function from the library
+    brisque_index: torch.Tensor = piq.brisque(prediction, data_range=1., reduction='none')
+    # In order to use BRISQUE as a loss function, use corresponding PyTorch module.
+    # Note: the back propagation is not available using torch==1.5.0.
+    # Update the environment with latest torch and torchvision.
+    brisque_loss: torch.Tensor = piq.BRISQUELoss(data_range=1., reduction='none')(prediction)
+    print(f"BRISQUE index: {brisque_index.item():0.4f}, loss: {brisque_loss.item():0.4f}")
+
+    # To compute Content score as a loss function, use corresponding PyTorch module
+    # By default VGG16 model is used, but any feature extractor model is supported.
+    # Don't forget to adjust layers names accordingly. Features from different layers can be weighted differently.
+    # Use weights parameter. See other options in class docstring.
+    content_loss = piq.ContentLoss(
+        feature_extractor="vgg16", layers=("relu3_3", ), reduction='none')(prediction, target)
+    print(f"ContentLoss: {content_loss.item():0.4f}")
+
+    # To compute DISTS as a loss function, use corresponding PyTorch module
+    # By default input images are normalized with ImageNet statistics before forwarding through VGG16 model.
+    # If there is no need to normalize the data, use mean=[0.0, 0.0, 0.0] and std=[1.0, 1.0, 1.0].
+    dists_loss = piq.DISTS(reduction='none')(prediction, target)
+    print(f"DISTS: {dists_loss.item():0.4f}")
+
+    # To compute FSIM as a measure, use lower case function from the library
+    fsim_index: torch.Tensor = piq.fsim(prediction, target, data_range=1., reduction='none')
+    # In order to use FSIM as a loss function, use corresponding PyTorch module
+    fsim_loss = piq.FSIMLoss(data_range=1., reduction='none')(prediction, target)
+    print(f"FSIM index: {fsim_index.item():0.4f}, loss: {fsim_loss.item():0.4f}")
+
+    # To compute GMSD as a measure, use lower case function from the library
+    # This is port of MATLAB version from the authors of original paper.
+    # In any case it should me minimized. Usually values of GMSD lie in [0, 0.35] interval.
+    gmsd_index: torch.Tensor = piq.gmsd(prediction, target, data_range=1., reduction='none')
+    # In order to use GMSD as a loss function, use corresponding PyTorch module:
+    gmsd_loss: torch.Tensor = piq.GMSDLoss(data_range=1., reduction='none')(prediction, target)
+    print(f"GMSD index: {gmsd_index.item():0.4f}, loss: {gmsd_loss.item():0.4f}")
+
+    # To compute HaarPSI as a measure, use lower case function from the library
+    # This is port of MATLAB version from the authors of original paper.
+    haarpsi_index: torch.Tensor = piq.haarpsi(prediction, target, data_range=1., reduction='none')
+    # In order to use HaarPSI as a loss function, use corresponding PyTorch module
+    haarpsi_loss: torch.Tensor = piq.HaarPSILoss(data_range=1., reduction='none')(prediction, target)
+    print(f"HaarPSI index: {haarpsi_index.item():0.4f}, loss: {haarpsi_loss.item():0.4f}")
+
+    # To compute LPIPS as a loss function, use corresponding PyTorch module
+    lpips_loss: torch.Tensor = piq.LPIPS(reduction='none')(prediction, target)
+    print(f"LPIPS: {lpips_loss.item():0.4f}")
+
+    # To compute MDSI as a measure, use lower case function from the library
+    mdsi_index: torch.Tensor = piq.mdsi(prediction, target, data_range=1., reduction='none')
+    # In order to use MDSI as a loss function, use corresponding PyTorch module
+    mdsi_loss: torch.Tensor = piq.MDSILoss(data_range=1., reduction='none')(prediction, target)
+    print(f"MDSI index: {mdsi_index.item():0.4f}, loss: {mdsi_loss.item():0.4f}")
+
+    # To compute MS-SSIM index as a measure, use lower case function from the library:
+    ms_ssim_index: torch.Tensor = piq.multi_scale_ssim(prediction, target, data_range=1.)
+    # In order to use MS-SSIM as a loss function, use corresponding PyTorch module:
+    ms_ssim_loss = piq.MultiScaleSSIMLoss(data_range=1., reduction='none')(prediction, target)
+    print(f"MS-SSIM index: {ms_ssim_index.item():0.4f}, loss: {ms_ssim_loss.item():0.4f}")
+
+    # To compute Multi-Scale GMSD as a measure, use lower case function from the library
+    # It can be used both as a measure and as a loss function. In any case it should me minimized.
+    # By defualt scale weights are initialized with values from the paper.
+    # You can change them by passing a list of 4 variables to scale_weights argument during initialization
+    # Note that input tensors should contain images with height and width equal 2 ** number_of_scales + 1 at least.
+    ms_gmsd_index: torch.Tensor = piq.multi_scale_gmsd(
+        prediction, target, data_range=1., chromatic=True, reduction='none')
+    # In order to use Multi-Scale GMSD as a loss function, use corresponding PyTorch module
+    ms_gmsd_loss: torch.Tensor = piq.MultiScaleGMSDLoss(
+        chromatic=True, data_range=1., reduction='none')(prediction, target)
+    print(f"MS-GMSDc index: {ms_gmsd_index.item():0.4f}, loss: {ms_gmsd_loss.item():0.4f}")
+
+    # To compute PSNR as a measure, use lower case function from the library.
+    psnr_index = piq.psnr(prediction, target, data_range=1., reduction='none')
+    print(f"PSNR index: {psnr_index.item():0.4f}")
+
+    # To compute SSIM index as a measure, use lower case function from the library:
+    ssim_index = piq.ssim(prediction, target, data_range=1.)
+    # In order to use SSIM as a loss function, use corresponding PyTorch module:
+    ssim_loss: torch.Tensor = piq.SSIMLoss(data_range=1.)(prediction, target)
+    print(f"SSIM index: {ssim_index.item():0.4f}, loss: {ssim_loss.item():0.4f}")
+
+    # To compute Style score as a loss function, use corresponding PyTorch module:
+    # By default VGG16 model is used, but any feature extractor model is supported.
+    # Don't forget to adjust layers names accordingly. Features from different layers can be weighted differently.
+    # Use weights parameter. See other options in class docstring.
+    style_loss = piq.StyleLoss(feature_extractor="vgg16", layers=("relu3_3", ))(prediction, target)
+    print(f"Style: {style_loss.item():0.4f}")
+
+    # To compute TV as a measure, use lower case function from the library:
+    tv_index: torch.Tensor = piq.total_variation(prediction)
+    # In order to use TV as a loss function, use corresponding PyTorch module:
+    tv_loss: torch.Tensor = piq.TVLoss(reduction='none')(prediction)
+    print(f"TV index: {tv_index.item():0.4f}, loss: {tv_loss.item():0.4f}")
+
+    # To compute VIF as a measure, use lower case function from the library:
+    vif_index: torch.Tensor = piq.vif_p(prediction, target, data_range=1.)
+    # In order to use VIF as a loss function, use corresponding PyTorch class:
+    vif_loss: torch.Tensor = piq.VIFLoss(sigma_n_sq=2.0, data_range=1.)(prediction, target)
+    print(f"VIFp index: {vif_index.item():0.4f}, loss: {vif_loss.item():0.4f}")
+
+    # To compute VSI score as a measure, use lower case function from the library:
+    vsi_index: torch.Tensor = piq.vsi(prediction, target, data_range=1.)
+    # In order to use VSI as a loss function, use corresponding PyTorch module:
+    vsi_loss: torch.Tensor = piq.VSILoss(data_range=1.)(prediction, target)
+    print(f"VSI index: {vsi_index.item():0.4f}, loss: {vsi_loss.item():0.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -22,6 +22,7 @@ def gmsd(prediction: torch.Tensor, target: torch.Tensor, reduction: Optional[str
          data_range: Union[int, float] = 1., t: float = 170 / (255. ** 2)) -> torch.Tensor:
     r"""Compute Gradient Magnitude Similarity Deviation
     Both inputs supposed to be in range [0, 1] with RGB order.
+    Usually values of GMSD lie in [0, 0.35] interval.
     Args:
         prediction: Tensor of shape :math:`(N, C, H, W)` holding an distorted image.
         target: Tensor of shape :math:`(N, C, H, W)` holding an target image
@@ -38,6 +39,7 @@ def gmsd(prediction: torch.Tensor, target: torch.Tensor, reduction: Optional[str
         gmsd : Gradient Magnitude Similarity Deviation between given tensors.
 
     References:
+        Wufeng Xue et al. Gradient Magnitude Similarity Deviation (2013)
         https://arxiv.org/pdf/1308.3052.pdf
     """
 
@@ -250,7 +252,6 @@ class MultiScaleGMSDLoss(_Loss):
     r"""Creates a criterion that measures multi scale Gradient Magnitude Similarity Deviation
     between each element in the input :math:`x` and target :math:`y`.
 
-
     Args:
         reduction: Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
@@ -260,13 +261,14 @@ class MultiScaleGMSDLoss(_Loss):
             i.e., if for image x it holds min(x) = 0 and max(x) = 1, then data_range = 1.
             The pixel value interval of both input and output should remain the same.
         scale_weights: Weights for different scales. Can contain any number of floating point values.
+            By defualt weights are initialized with values from the paper.
         chromatic: Flag to use MS-GMSDc algorithm from paper.
             It also evaluates chromatic components of the image. Default: True
         beta1: Algorithm parameter. Weight of chromatic component in the loss.
         beta2: Algorithm parameter. Small constant, see [1].
         beta3: Algorithm parameter. Small constant, see [1].
         t: Constant from the reference paper numerical stability of similarity map
-        
+
     Reference:
         [1] GRADIENT MAGNITUDE SIMILARITY DEVIATION ON MULTIPLE SCALES (2017)
             http://www.cse.ust.hk/~psander/docs/gradsim.pdf

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -277,7 +277,7 @@ class MultiScaleGMSDLoss(_Loss):
     def __init__(self, reduction: str = 'mean', data_range: Union[int, float] = 1.,
                  scale_weights: Optional[Union[torch.Tensor, Tuple[float, ...], List[float]]] = None,
                  chromatic: bool = False, alpha: float = 0.5, beta1: float = 0.01, beta2: float = 0.32,
-                 beta3: float = 15., t: float = 170 / (255. ** 2)) -> None:
+                 beta3: float = 15., t: float = 170) -> None:
         super().__init__()
 
         # Generic loss parameters.

--- a/piq/gs.py
+++ b/piq/gs.py
@@ -152,8 +152,8 @@ class GS(BaseFeatureMetric):
 
     Note:
         Computation is heavily CPU dependent, adjust `num_workers` parameter according to your system configuration.
-        GS metric requiers `gudhi` library which is not installed by default. 
-        For conda, write: `conda install -c conda-forge gudhi`, 
+        GS metric requiers `gudhi` library which is not installed by default.
+        For conda, write: `conda install -c conda-forge gudhi`,
             otherwise follow installation guide: http://gudhi.gforge.inria.fr/python/latest/installation.html
 
     """

--- a/piq/gs.py
+++ b/piq/gs.py
@@ -133,7 +133,7 @@ class GS(BaseFeatureMetric):
     r"""Interface of Geometry Score.
     It's computed for a whole set of data and can use features from encoder instead of images itself to decrease
     computation cost. GS can compare two data distributions with different number of samples.
-    But dimensionalities should match, otherwise it won't be possible to correctly compute statistics.
+    Dimensionalities of features should match, otherwise it won't be possible to correctly compute statistics.
 
     Args:
         predicted_features (torch.Tensor): Low-dimension representation of predicted image set.
@@ -149,6 +149,13 @@ class GS(BaseFeatureMetric):
         Geometry score: A method for comparing generative adversarial networks.
         arXiv preprint, 2018.
         https://arxiv.org/abs/1802.02664
+
+    Note:
+        Computation is heavily CPU dependent, adjust `num_workers` parameter according to your system configuration.
+        GS metric requiers `gudhi` library which is not installed by default. 
+        For conda, write: `conda install -c conda-forge gudhi`, 
+            otherwise follow installation guide: http://gudhi.gforge.inria.fr/python/latest/installation.html
+
     """
     def __init__(self, sample_size: int = 64, num_iters: int = 1000, gamma: Optional[float] = None,
                  i_max: int = 100, num_workers: int = 4) -> None:

--- a/piq/isc.py
+++ b/piq/isc.py
@@ -29,7 +29,9 @@ def inception_score(features: torch.Tensor, num_splits: int = 10):
         score, variance:
 
     Reference:
+        "A Note on the Inception Score"
         https://arxiv.org/pdf/1801.01973.pdf
+
     """
     assert len(features.shape) == 2, \
         f"Features must have shape (N_samples, encoder_dim), got {features.shape}"

--- a/piq/perceptual.py
+++ b/piq/perceptual.py
@@ -261,6 +261,7 @@ class LPIPS(ContentLoss):
         (2018) The Unreasonable Effectiveness of Deep Features as a Perceptual Metric
         2018 IEEE/CVF Conference on Computer Vision and Pattern Recognition
         https://arxiv.org/abs/1801.03924
+        https://github.com/richzhang/PerceptualSimilarity
     """
     _weights_url = "https://github.com/photosynthesis-team/" + \
         "photosynthesis.metrics/releases/download/v0.4.0/lpips_weights.pt"

--- a/piq/psnr.py
+++ b/piq/psnr.py
@@ -18,11 +18,12 @@ def psnr(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1.0,
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         convert_to_greyscale: Convert RGB image to YCbCr format and computes PSNR
             only on luminance channel if `True`. Compute on all 3 channels otherwise.
-        
+
     Returns:
         PSNR: Index of similarity betwen two images.
-    Note:
-        Implementaition is based on Wikepedia https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
+
+    References:
+        https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
     """
     _validate_input((x, y), allow_5d=False)
     x, y = _adjust_dimensions(input_tensors=(x, y))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,10 @@
+from examples.feature_metrics import main as feature_metrics_examples
+from examples.image_metrics import main as image_metrics_examples
+
+
+def test_image_metrics():
+    image_metrics_examples()
+
+
+def test_feature_metrics():
+    feature_metrics_examples()


### PR DESCRIPTION
Closes #150 

Main reason for this update is to improve search engine optimization and increase library user base. Before update text in blocks wasn't parsed and some metrics (VIF, VSI) couldn't be found in Google or Yandex despite being implemented more than 4 month ago. Now this should change

## Proposed Changes

  - List all metrics with links to papers as a list, not blocks
  - Add description of competitive advantages on top
  - Make examples part shorter
  - Move some metric related info into doc strings