### PR TITLE
Unify input tensors name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ as a loss function.
 import torch
 from piq import ssim, SSIMLoss
 
-prediction = torch.rand(4, 3, 256, 256, requires_grad=True)
-target = torch.rand(4, 3, 256, 256)
+x = torch.rand(4, 3, 256, 256, requires_grad=True)
+y = torch.rand(4, 3, 256, 256)
 
-ssim_index: torch.Tensor = ssim(prediction, target, data_range=1.)
+ssim_index: torch.Tensor = ssim(x, y, data_range=1.)
 
 loss = SSIMLoss(data_range=1.)
-output: torch.Tensor = loss(prediction, target)
+output: torch.Tensor = loss(x, y)
 output.backward()
 ```
 
@@ -65,12 +65,12 @@ If you already have image features, use the class interface for score computatio
 
 ```python
 import torch
-from piq import FID
+from piq import MSID
 
-prediction_feats = torch.rand(10000, 1024)
-target_feats = torch.rand(10000, 1024)
+x_feats = torch.rand(10000, 1024)
+y_feats = torch.rand(10000, 1024)
 msid_metric = MSID()
-msid: torch.Tensor = msid_metric(prediction_feats, target_feats)
+msid: torch.Tensor = msid_metric(x_feats, y_feats)
 ```
 
 For a full list of examples, see [image metrics](examples/image_metrics.py) and [feature metrics](examples/feature_metrics.py) examples.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -11,13 +11,13 @@ as a loss function.
     import torch
     from piq import ssim, SSIMLoss
 
-    prediction = torch.rand(4, 3, 256, 256, requires_grad=True)
-    target = torch.rand(4, 3, 256, 256)
+    x = torch.rand(4, 3, 256, 256, requires_grad=True)
+    y = torch.rand(4, 3, 256, 256)
 
-    ssim_index: torch.Tensor = ssim(prediction, target, data_range=1.)
+    ssim_index: torch.Tensor = ssim(x, y, data_range=1.)
 
     loss = SSIMLoss(data_range=1.)
-    output: torch.Tensor = loss(prediction, target)
+    output: torch.Tensor = loss(x, y)
     output.backward()
 
 For a full list of examples, see `image metrics <https://github.com/photosynthesis-team/piq/blob/master/examples/image_metrics.py>`_ examples.
@@ -52,10 +52,10 @@ If you already have image features, use the class interface for score computatio
     import torch
     from piq import FID
 
-    prediction_feats = torch.rand(10000, 1024)
-    target_feats = torch.rand(10000, 1024)
+    x_feats = torch.rand(10000, 1024)
+    y_feats = torch.rand(10000, 1024)
     msid_metric = MSID()
-    msid: torch.Tensor = msid_metric(prediction_feats, target_feats)
+    msid: torch.Tensor = msid_metric(x_feats, y_feats)
 
 
 For a full list of examples, see `feature metrics <https://github.com/photosynthesis-team/piq/blob/master/examples/feature_metrics.py>`_ examples.

--- a/examples/feature_metrics.py
+++ b/examples/feature_metrics.py
@@ -4,16 +4,16 @@ import piq
 
 @torch.no_grad()
 def main():
-    prediction_features = torch.rand(2000, 128)
-    target_features = torch.rand(2000, 128)
+    x_features = torch.rand(2000, 128)
+    y_features = torch.rand(2000, 128)
 
     if torch.cuda.is_available():
         # Move to GPU to make computaions faster
-        prediction_features = prediction_features.cuda()
-        target_features = target_features.cuda()
+        x_features = x_features.cuda()
+        y_features = y_features.cuda()
 
     # Use FID class to compute FID score from image features, pre-extracted from some feature extractor network
-    fid: torch.Tensor = piq.FID()(prediction_features, target_features)
+    fid: torch.Tensor = piq.FID()(x_features, y_features)
     print(f"FID: {fid:0.4f}")
 
     # If image features are not available, extract them using compute_feats of FID class.
@@ -21,23 +21,22 @@ def main():
 
     # Use GS class to compute Geometry Score from image features, pre-extracted from some feature extractor network.
     # Computation is heavily CPU dependent, adjust num_workers parameter according to your system configuration.
-    gs: torch.Tensor = piq.GS(
-        sample_size=64, num_iters=100, i_max=100, num_workers=4)(prediction_features, target_features)
+    gs: torch.Tensor = piq.GS(sample_size=64, num_iters=100, i_max=100, num_workers=4)(x_features, y_features)
     print(f"GS: {gs:0.4f}")
 
     # Use inception_score function to compute IS from image features, pre-extracted from some feature extractor network.
     # Note, that we follow recomendations from paper "A Note on the Inception Score"
-    isc_mean, _ = piq.inception_score(prediction_features, num_splits=10)
+    isc_mean, _ = piq.inception_score(x_features, num_splits=10)
     # To compute difference between IS for 2 sets of image features, use IS class.
-    isc: torch.Tensor = piq.IS(distance='l1')(prediction_features, target_features)
+    isc: torch.Tensor = piq.IS(distance='l1')(x_features, y_features)
     print(f"IS: {isc_mean:0.4f}, difference: {isc:0.4f}")
 
     # Use KID class to compute KID score from image features, pre-extracted from some feature extractor network:
-    kid: torch.Tensor = piq.KID()(prediction_features, target_features)
+    kid: torch.Tensor = piq.KID()(x_features, y_features)
     print(f"KID: {kid:0.4f}")
 
     # Use MSID class to compute MSID score from image features, pre-extracted from some feature extractor network:
-    msid: torch.Tensor = piq.MSID()(prediction_features, target_features)
+    msid: torch.Tensor = piq.MSID()(x_features, y_features)
     print(f"MSID: {msid:0.4f}")
 
 

--- a/examples/image_metrics.py
+++ b/examples/image_metrics.py
@@ -6,20 +6,20 @@ from skimage.io import imread
 @torch.no_grad()
 def main():
     # Read RGB image and it's noisy version
-    prediction = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1) / 255.
-    target = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1) / 255.
+    x = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1) / 255.
+    y = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1) / 255.
     
     if torch.cuda.is_available():
         # Move to GPU to make computaions faster
-        prediction = prediction.cuda()
-        target = target.cuda()
+        x = x.cuda()
+        y = y.cuda()
 
     # To compute BRISQUE score as a measure, use lower case function from the library
-    brisque_index: torch.Tensor = piq.brisque(prediction, data_range=1., reduction='none')
+    brisque_index: torch.Tensor = piq.brisque(x, data_range=1., reduction='none')
     # In order to use BRISQUE as a loss function, use corresponding PyTorch module.
     # Note: the back propagation is not available using torch==1.5.0.
     # Update the environment with latest torch and torchvision.
-    brisque_loss: torch.Tensor = piq.BRISQUELoss(data_range=1., reduction='none')(prediction)
+    brisque_loss: torch.Tensor = piq.BRISQUELoss(data_range=1., reduction='none')(x)
     print(f"BRISQUE index: {brisque_index.item():0.4f}, loss: {brisque_loss.item():0.4f}")
 
     # To compute Content score as a loss function, use corresponding PyTorch module
@@ -27,50 +27,50 @@ def main():
     # Don't forget to adjust layers names accordingly. Features from different layers can be weighted differently.
     # Use weights parameter. See other options in class docstring.
     content_loss = piq.ContentLoss(
-        feature_extractor="vgg16", layers=("relu3_3", ), reduction='none')(prediction, target)
+        feature_extractor="vgg16", layers=("relu3_3", ), reduction='none')(x, y)
     print(f"ContentLoss: {content_loss.item():0.4f}")
 
     # To compute DISTS as a loss function, use corresponding PyTorch module
     # By default input images are normalized with ImageNet statistics before forwarding through VGG16 model.
     # If there is no need to normalize the data, use mean=[0.0, 0.0, 0.0] and std=[1.0, 1.0, 1.0].
-    dists_loss = piq.DISTS(reduction='none')(prediction, target)
+    dists_loss = piq.DISTS(reduction='none')(x, y)
     print(f"DISTS: {dists_loss.item():0.4f}")
 
     # To compute FSIM as a measure, use lower case function from the library
-    fsim_index: torch.Tensor = piq.fsim(prediction, target, data_range=1., reduction='none')
+    fsim_index: torch.Tensor = piq.fsim(x, y, data_range=1., reduction='none')
     # In order to use FSIM as a loss function, use corresponding PyTorch module
-    fsim_loss = piq.FSIMLoss(data_range=1., reduction='none')(prediction, target)
+    fsim_loss = piq.FSIMLoss(data_range=1., reduction='none')(x, y)
     print(f"FSIM index: {fsim_index.item():0.4f}, loss: {fsim_loss.item():0.4f}")
 
     # To compute GMSD as a measure, use lower case function from the library
     # This is port of MATLAB version from the authors of original paper.
     # In any case it should me minimized. Usually values of GMSD lie in [0, 0.35] interval.
-    gmsd_index: torch.Tensor = piq.gmsd(prediction, target, data_range=1., reduction='none')
+    gmsd_index: torch.Tensor = piq.gmsd(x, y, data_range=1., reduction='none')
     # In order to use GMSD as a loss function, use corresponding PyTorch module:
-    gmsd_loss: torch.Tensor = piq.GMSDLoss(data_range=1., reduction='none')(prediction, target)
+    gmsd_loss: torch.Tensor = piq.GMSDLoss(data_range=1., reduction='none')(x, y)
     print(f"GMSD index: {gmsd_index.item():0.4f}, loss: {gmsd_loss.item():0.4f}")
 
     # To compute HaarPSI as a measure, use lower case function from the library
     # This is port of MATLAB version from the authors of original paper.
-    haarpsi_index: torch.Tensor = piq.haarpsi(prediction, target, data_range=1., reduction='none')
+    haarpsi_index: torch.Tensor = piq.haarpsi(x, y, data_range=1., reduction='none')
     # In order to use HaarPSI as a loss function, use corresponding PyTorch module
-    haarpsi_loss: torch.Tensor = piq.HaarPSILoss(data_range=1., reduction='none')(prediction, target)
+    haarpsi_loss: torch.Tensor = piq.HaarPSILoss(data_range=1., reduction='none')(x, y)
     print(f"HaarPSI index: {haarpsi_index.item():0.4f}, loss: {haarpsi_loss.item():0.4f}")
 
     # To compute LPIPS as a loss function, use corresponding PyTorch module
-    lpips_loss: torch.Tensor = piq.LPIPS(reduction='none')(prediction, target)
+    lpips_loss: torch.Tensor = piq.LPIPS(reduction='none')(x, y)
     print(f"LPIPS: {lpips_loss.item():0.4f}")
 
     # To compute MDSI as a measure, use lower case function from the library
-    mdsi_index: torch.Tensor = piq.mdsi(prediction, target, data_range=1., reduction='none')
+    mdsi_index: torch.Tensor = piq.mdsi(x, y, data_range=1., reduction='none')
     # In order to use MDSI as a loss function, use corresponding PyTorch module
-    mdsi_loss: torch.Tensor = piq.MDSILoss(data_range=1., reduction='none')(prediction, target)
+    mdsi_loss: torch.Tensor = piq.MDSILoss(data_range=1., reduction='none')(x, y)
     print(f"MDSI index: {mdsi_index.item():0.4f}, loss: {mdsi_loss.item():0.4f}")
 
     # To compute MS-SSIM index as a measure, use lower case function from the library:
-    ms_ssim_index: torch.Tensor = piq.multi_scale_ssim(prediction, target, data_range=1.)
+    ms_ssim_index: torch.Tensor = piq.multi_scale_ssim(x, y, data_range=1.)
     # In order to use MS-SSIM as a loss function, use corresponding PyTorch module:
-    ms_ssim_loss = piq.MultiScaleSSIMLoss(data_range=1., reduction='none')(prediction, target)
+    ms_ssim_loss = piq.MultiScaleSSIMLoss(data_range=1., reduction='none')(x, y)
     print(f"MS-SSIM index: {ms_ssim_index.item():0.4f}, loss: {ms_ssim_loss.item():0.4f}")
 
     # To compute Multi-Scale GMSD as a measure, use lower case function from the library
@@ -79,49 +79,49 @@ def main():
     # You can change them by passing a list of 4 variables to scale_weights argument during initialization
     # Note that input tensors should contain images with height and width equal 2 ** number_of_scales + 1 at least.
     ms_gmsd_index: torch.Tensor = piq.multi_scale_gmsd(
-        prediction, target, data_range=1., chromatic=True, reduction='none')
+        x, y, data_range=1., chromatic=True, reduction='none')
     # In order to use Multi-Scale GMSD as a loss function, use corresponding PyTorch module
     ms_gmsd_loss: torch.Tensor = piq.MultiScaleGMSDLoss(
-        chromatic=True, data_range=1., reduction='none')(prediction, target)
+        chromatic=True, data_range=1., reduction='none')(x, y)
     print(f"MS-GMSDc index: {ms_gmsd_index.item():0.4f}, loss: {ms_gmsd_loss.item():0.4f}")
 
     # To compute PSNR as a measure, use lower case function from the library.
-    psnr_index = piq.psnr(prediction, target, data_range=1., reduction='none')
+    psnr_index = piq.psnr(x, y, data_range=1., reduction='none')
     print(f"PSNR index: {psnr_index.item():0.4f}")
     
     # To compute PieAPP as a loss function, use corresponding PyTorch module:
-    pieapp_loss: torch.Tensor = piq.PieAPP(reduction='none', stride=32)(prediction, target)
+    pieapp_loss: torch.Tensor = piq.PieAPP(reduction='none', stride=32)(x, y)
     print(f"PieAPP loss: {pieapp_loss.item():0.4f}")
 
     # To compute SSIM index as a measure, use lower case function from the library:
-    ssim_index = piq.ssim(prediction, target, data_range=1.)
+    ssim_index = piq.ssim(x, y, data_range=1.)
     # In order to use SSIM as a loss function, use corresponding PyTorch module:
-    ssim_loss: torch.Tensor = piq.SSIMLoss(data_range=1.)(prediction, target)
+    ssim_loss: torch.Tensor = piq.SSIMLoss(data_range=1.)(x, y)
     print(f"SSIM index: {ssim_index.item():0.4f}, loss: {ssim_loss.item():0.4f}")
 
     # To compute Style score as a loss function, use corresponding PyTorch module:
     # By default VGG16 model is used, but any feature extractor model is supported.
     # Don't forget to adjust layers names accordingly. Features from different layers can be weighted differently.
     # Use weights parameter. See other options in class docstring.
-    style_loss = piq.StyleLoss(feature_extractor="vgg16", layers=("relu3_3", ))(prediction, target)
+    style_loss = piq.StyleLoss(feature_extractor="vgg16", layers=("relu3_3", ))(x, y)
     print(f"Style: {style_loss.item():0.4f}")
 
     # To compute TV as a measure, use lower case function from the library:
-    tv_index: torch.Tensor = piq.total_variation(prediction)
+    tv_index: torch.Tensor = piq.total_variation(x)
     # In order to use TV as a loss function, use corresponding PyTorch module:
-    tv_loss: torch.Tensor = piq.TVLoss(reduction='none')(prediction)
+    tv_loss: torch.Tensor = piq.TVLoss(reduction='none')(x)
     print(f"TV index: {tv_index.item():0.4f}, loss: {tv_loss.item():0.4f}")
 
     # To compute VIF as a measure, use lower case function from the library:
-    vif_index: torch.Tensor = piq.vif_p(prediction, target, data_range=1.)
+    vif_index: torch.Tensor = piq.vif_p(x, y, data_range=1.)
     # In order to use VIF as a loss function, use corresponding PyTorch class:
-    vif_loss: torch.Tensor = piq.VIFLoss(sigma_n_sq=2.0, data_range=1.)(prediction, target)
+    vif_loss: torch.Tensor = piq.VIFLoss(sigma_n_sq=2.0, data_range=1.)(x, y)
     print(f"VIFp index: {vif_index.item():0.4f}, loss: {vif_loss.item():0.4f}")
 
     # To compute VSI score as a measure, use lower case function from the library:
-    vsi_index: torch.Tensor = piq.vsi(prediction, target, data_range=1.)
+    vsi_index: torch.Tensor = piq.vsi(x, y, data_range=1.)
     # In order to use VSI as a loss function, use corresponding PyTorch module:
-    vsi_loss: torch.Tensor = piq.VSILoss(data_range=1.)(prediction, target)
+    vsi_loss: torch.Tensor = piq.VSILoss(data_range=1.)(x, y)
     print(f"VSI index: {vsi_index.item():0.4f}, loss: {vsi_loss.item():0.4f}")
 
 

--- a/piq/base.py
+++ b/piq/base.py
@@ -12,10 +12,10 @@ class BaseFeatureMetric(torch.nn.Module):
     def __init__(self) -> None:
         super(BaseFeatureMetric, self).__init__()
 
-    def forward(self, predicted_features: torch.Tensor, target_features: torch.Tensor) -> torch.Tensor:
+    def forward(self, x_features: torch.Tensor, y_features: torch.Tensor) -> torch.Tensor:
         # Sanity check for input
-        _validate_features(predicted_features, target_features)
-        return self.compute_metric(predicted_features, target_features)
+        _validate_features(x_features, y_features)
+        return self.compute_metric(x_features, y_features)
 
     @torch.no_grad()
     def compute_feats(
@@ -57,5 +57,5 @@ class BaseFeatureMetric(torch.nn.Module):
 
         return torch.cat(total_feats, dim=0)
 
-    def compute_metric(self, predicted_features: torch.Tensor, target_features: torch.Tensor) -> torch.Tensor:
+    def compute_metric(self, x_features: torch.Tensor, y_features: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("This function should be defined for each children class")

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -96,9 +96,9 @@ class BRISQUELoss(_Loss):
 
     Examples::
         >>> loss = BRISQUELoss()
-        >>> prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-        >>> target = torch.rand(3, 3, 256, 256)
-        >>> output = loss(prediction)
+        >>> x = torch.rand(3, 3, 256, 256, requires_grad=True)
+        >>> y = torch.rand(3, 3, 256, 256)
+        >>> output = loss(x)
         >>> output.backward()
 
     Note:
@@ -119,16 +119,16 @@ class BRISQUELoss(_Loss):
         self.data_range = data_range
         self.interpolation = interpolation
 
-    def forward(self, prediction: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         r"""Computation of BRISQUE score as a loss function.
 
         Args:
-            prediction: Tensor of prediction of the network.
+            x: Tensor of prediction of the network.
 
         Returns:
             Value of BRISQUE loss to be minimized.
         """
-        return brisque(prediction, reduction=self.reduction, kernel_size=self.kernel_size,
+        return brisque(x, reduction=self.reduction, kernel_size=self.kernel_size,
                        kernel_sigma=self.kernel_sigma, data_range=self.data_range, interpolation=self.interpolation)
 
 

--- a/piq/fid.py
+++ b/piq/fid.py
@@ -64,15 +64,15 @@ def _sqrtm_newton_schulz(matrix: torch.Tensor, num_iters: int = 100) -> Tuple[to
 def _compute_fid(mu1: torch.Tensor, sigma1: torch.Tensor, mu2: torch.Tensor, sigma2: torch.Tensor,
                  eps=1e-6) -> torch.Tensor:
     r"""
-    The Frechet Inception Distance between two multivariate Gaussians X_predicted ~ N(mu_1, sigm_1)
-    and X_target ~ N(mu_2, sigm_2) is
+    The Frechet Inception Distance between two multivariate Gaussians X_x ~ N(mu_1, sigm_1)
+    and X_y ~ N(mu_2, sigm_2) is
         d^2 = ||mu_1 - mu_2||^2 + Tr(sigm_1 + sigm_2 - 2*sqrt(sigm_1*sigm_2)).
 
     Args:
-        mu1: mean of activations calculated on predicted samples
-        sigma1: covariance matrix over activations calculated on predicted samples
-        mu2: mean of activations calculated on target samples
-        sigma2: covariance matrix over activations calculated on target samples
+        mu1: mean of activations calculated on predicted (x) samples
+        sigma1: covariance matrix over activations calculated on predicted (x) samples
+        mu2: mean of activations calculated on target (y) samples
+        sigma2: covariance matrix over activations calculated on target (y) samples
         eps: offset constant. used if sigma_1 @ sigma_2 matrix is singular
 
     Returns:
@@ -149,8 +149,8 @@ class FID(BaseFeatureMetric):
     But dimensionalities should match, otherwise it won't be possible to correctly compute statistics.
 
     Args:
-        predicted_features: Low-dimension representation of predicted image set. Shape (N_pred, encoder_dim)
-        target_features: Low-dimension representation of target image set. Shape (N_targ, encoder_dim)
+        x_features: Low-dimension representation of predicted image set :math:`x`. Shape (N_x, encoder_dim)
+        y_features: Low-dimension representation of target image set :math:`y`. Shape (N_y, encoder_dim)
 
     Returns:
         score: Scalar value of the distance between image sets features.
@@ -163,24 +163,24 @@ class FID(BaseFeatureMetric):
            https://arxiv.org/abs/1706.08500
     """
 
-    def compute_metric(self, predicted_features: torch.Tensor, target_features: torch.Tensor) -> torch.Tensor:
+    def compute_metric(self, x_features: torch.Tensor, y_features: torch.Tensor) -> torch.Tensor:
         r"""
         Fits multivariate Gaussians: X ~ N(mu_1, sigm_1) and Y ~ N(mu_2, sigm_2) to image stacks.
         Then computes FID as d^2 = ||mu_1 - mu_2||^2 + Tr(sigm_1 + sigm_2 - 2*sqrt(sigm_1*sigm_2)).
 
         Args:
-            predicted_features: Samples from data distribution.
+            x_features: Samples from data distribution.
                 Shape (N_samples, data_dim), dtype: torch.float32 in range 0 - 1.
-            target_features: Samples from data distribution.
+            y_features: Samples from data distribution.
                 Shape (N_samples, data_dim), dtype: torch.float32 in range 0 - 1
 
         Returns:
         --   : The Frechet Distance.
         """
         # GPU -> CPU
-        m_pred, s_pred = _compute_statistics(predicted_features.detach().to(dtype=torch.float64))
-        m_targ, s_targ = _compute_statistics(target_features.detach().to(dtype=torch.float64))
+        mu_x, sigma_x = _compute_statistics(x_features.detach().to(dtype=torch.float64))
+        mu_y, sigma_y = _compute_statistics(y_features.detach().to(dtype=torch.float64))
 
-        score = _compute_fid(m_pred, s_pred, m_targ, s_targ)
+        score = _compute_fid(mu_x, sigma_x, mu_y, sigma_y)
 
         return score.to(dtype=torch.float32)

--- a/piq/haarpsi.py
+++ b/piq/haarpsi.py
@@ -170,9 +170,9 @@ class HaarPSILoss(_Loss):
     Examples::
 
         >>> loss = HaarPSILoss()
-        >>> prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-        >>> target = torch.rand(3, 3, 256, 256)
-        >>> output = loss(prediction, target)
+        >>> x = torch.rand(3, 3, 256, 256, requires_grad=True)
+        >>> y = torch.rand(3, 3, 256, 256)
+        >>> output = loss(x, y)
         >>> output.backward()
 
     References:
@@ -190,15 +190,15 @@ class HaarPSILoss(_Loss):
             haarpsi, scales=scales, subsample=subsample, c=c, alpha=alpha,
             data_range=data_range, reduction=reduction)
 
-    def forward(self, prediction, target):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         r"""Computation of HaarPSI as a loss function.
 
         Args:
-            prediction: Tensor of prediction of the network.
-            target: Reference tensor.
+            x: Tensor of predictions of the network.
+            y: Reference tensor.
 
         Returns:
             Value of HaarPSI loss to be minimized. 0 <= HaarPSI loss <= 1.
         """
 
-        return 1. - self.haarpsi(x=prediction, y=target)
+        return 1. - self.haarpsi(x=x, y=y)

--- a/piq/kid.py
+++ b/piq/kid.py
@@ -5,12 +5,8 @@ import torch
 from piq.base import BaseFeatureMetric
 
 
-def _polynomial_kernel(
-        X: torch.Tensor,
-        Y: torch.Tensor = None,
-        degree: int = 3,
-        gamma: Optional[float] = None,
-        coef0: float = 1.) -> torch.Tensor:
+def _polynomial_kernel(X: torch.Tensor, Y: torch.Tensor = None, degree: int = 3, gamma: Optional[float] = None,
+                       coef0: float = 1.) -> torch.Tensor:
     """
     Compute the polynomial kernel between x and y
     K(X, Y) = (gamma <X, Y> + coef0)^degree
@@ -50,15 +46,9 @@ def _polynomial_kernel(
     return K
 
 
-def _mmd2_and_variance(
-        K_XX: torch.Tensor,
-        K_XY: torch.Tensor,
-        K_YY: torch.Tensor,
-        unit_diagonal: bool = False,
-        mmd_est: str = 'unbiased',
-        var_at_m: Optional[int] = None,
-        ret_var: bool = False
-) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+def _mmd2_and_variance(K_XX: torch.Tensor, K_XY: torch.Tensor, K_YY: torch.Tensor, unit_diagonal: bool = False,
+                       mmd_est: str = 'unbiased', var_at_m: Optional[int] = None, ret_var: bool = False) \
+        -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     # based on
     # https://github.com/dougalsutherland/opt-mmd/blob/master/two_sample/mmd.py
     # but changed to not compute the full kernel matrix at once
@@ -152,9 +142,10 @@ class KID(BaseFeatureMetric):
     But dimensionalities should match, otherwise it won't be possible to correctly compute statistics.
 
     Args:
-        predicted_features: Low-dimension representation of predicted image set.
-            Shape (N_pred, encoder_dim)
-        target_features: Low-dimension representation of target image set. Shape (N_targ, encoder_dim)
+        x_features: Low-dimension representation of predicted image set :math:`x`.
+            Shape (N_x, encoder_dim)
+        y_features: Low-dimension representation of target image set :math:`y`.
+            Shape (N_y, encoder_dim)
 
     Returns:
         score: Scalar value of the distance between image sets features.
@@ -164,17 +155,9 @@ class KID(BaseFeatureMetric):
         Demystifying MMD GANs https://arxiv.org/abs/1801.01401
     """
 
-    def __init__(
-            self,
-            degree: int = 3,
-            gamma: Optional[float] = None,
-            coef0: int = 1,
-            var_at_m: Optional[int] = None,
-            average: bool = False,
-            n_subsets: int = 50,
-            subset_size: Optional[int] = 1000,
-            ret_var: bool = False
-    ) -> None:
+    def __init__(self, degree: int = 3, gamma: Optional[float] = None, coef0: int = 1, var_at_m: Optional[int] = None,
+                 average: bool = False, n_subsets: int = 50, subset_size: Optional[int] = 1000, ret_var: bool = False
+                 ) -> None:
         r"""
         Creates a criterion that measures Kernel Inception Distance (polynomial MMD) for two datasets of images.
 
@@ -203,51 +186,48 @@ class KID(BaseFeatureMetric):
             self.n_subsets = 1
             self.subset_size = None
 
-    def compute_metric(
-            self,
-            predicted_features: torch.Tensor,
-            target_features: torch.Tensor,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    def compute_metric(self, x_features: torch.Tensor, y_features: torch.Tensor) \
+            -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         """Computes KID (polynomial MMD) for given sets of features, obtained from Inception net
         or any other feature extractor.
 
         Args:
-            predicted_features: Samples from data distribution.
+            x_features: Samples from data distribution.
                 Shape (N_samples, data_dim), dtype: torch.float32 in range [0, 1].
-            target_features: Samples from data distribution.
+            y_features: Samples from data distribution.
                 Shape (N_samples, data_dim), dtype: torch.float32 in range [0, 1].
 
         Returns:
             KID score and variance (optional).
         """
-        var_at_m = min(predicted_features.size(0), target_features.size(0))
+        var_at_m = min(x_features.size(0), y_features.size(0))
         if self.subset_size is None:
-            subset_size = predicted_features.size(0)
+            subset_size = x_features.size(0)
         else:
             subset_size = self.subset_size
 
         results = []
         for _ in range(self.n_subsets):
-            pred_subset = predicted_features[torch.randperm(len(predicted_features))[:subset_size]]
-            trgt_subset = target_features[torch.randperm(len(target_features))[:subset_size]]
+            x_subset = x_features[torch.randperm(len(x_features))[:subset_size]]
+            y_subset = y_features[torch.randperm(len(y_features))[:subset_size]]
 
             # use  k(x, y) = (gamma <x, y> + coef0)^degree
             # default gamma is 1 / dim
             K_XX = _polynomial_kernel(
-                pred_subset,
+                x_subset,
                 None,
                 degree=self.degree,
                 gamma=self.gamma,
                 coef0=self.coef0)
             K_YY = _polynomial_kernel(
-                trgt_subset,
+                y_subset,
                 None,
                 degree=self.degree,
                 gamma=self.gamma,
                 coef0=self.coef0)
             K_XY = _polynomial_kernel(
-                pred_subset,
-                trgt_subset,
+                x_subset,
+                y_subset,
                 degree=self.degree,
                 gamma=self.gamma,
                 coef0=self.coef0)

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -88,9 +88,9 @@ def mdsi(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1., r
 
     cs_total = (2 * (x_lhm[:, 1:2] * y_lhm[:, 1:2] +
                      x_lhm[:, 2:] * y_lhm[:, 2:]) + c3) / (x_lhm[:, 1:2] ** 2 +
-                                                                         y_lhm[:, 1:2] ** 2 +
-                                                                         x_lhm[:, 2:] ** 2 +
-                                                                         y_lhm[:, 2:] ** 2 + c3)
+                                                           y_lhm[:, 1:2] ** 2 +
+                                                           x_lhm[:, 2:] ** 2 +
+                                                           y_lhm[:, 2:] ** 2 + c3)
 
     if combination == 'sum':
         gcs = (alpha * gs_total + (1 - alpha) * cs_total)
@@ -154,6 +154,7 @@ class MDSILoss(_Loss):
            https://ieeexplore.ieee.org/abstract/document/7556976/,
            DOI:`10.1109/ACCESS.2016.2604042`
     """
+
     def __init__(self, data_range: Union[int, float] = 1., reduction: str = 'mean',
                  c1: float = 140., c2: float = 55., c3: float = 550., alpha: float = 0.6,
                  rho: float = 1., q: float = 0.25, o: float = 0.25, combination: str = 'sum',

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -15,7 +15,7 @@ from piq.functional import rgb2lhm, gradient_map, similarity_map, prewitt_filter
 from piq.utils import _validate_input, _adjust_dimensions
 
 
-def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, float] = 1., reduction: str = 'mean',
+def mdsi(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1., reduction: str = 'mean',
          c1: float = 140., c2: float = 55., c3: float = 550., combination: str = 'sum', alpha: float = 0.6,
          beta: float = 0.1, gamma: float = 0.2, rho: float = 1., q: float = 0.25, o: float = 0.25):
     r"""Compute Mean Deviation Similarity Index (MDSI) for a batch of images.
@@ -25,8 +25,8 @@ def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, 
         Greyscale images converted to RGB by copying the grey channel 3 times.
 
     Args:
-        prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
-        target:Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        x: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+        y:Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         c1: coefficient to calculate gradient similarity. Default: 140.
@@ -46,51 +46,51 @@ def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, 
     Note:
         The ratio between constants is usually equal c3 = 4c1 = 10c2
     """
-    _validate_input(input_tensors=(prediction, target), allow_5d=False, data_range=data_range)
-    prediction, target = _adjust_dimensions(input_tensors=(prediction, target))
+    _validate_input(input_tensors=(x, y), allow_5d=False, data_range=data_range)
+    x, y = _adjust_dimensions(input_tensors=(x, y))
 
-    if prediction.size(1) == 1:
-        prediction = prediction.repeat(1, 3, 1, 1)
-        target = target.repeat(1, 3, 1, 1)
+    if x.size(1) == 1:
+        x = x.repeat(1, 3, 1, 1)
+        y = y.repeat(1, 3, 1, 1)
         warnings.warn('The original MDSI supports only RGB images. The input images were converted to RGB by copying '
                       'the grey channel 3 times.')
 
-    prediction = prediction / data_range * 255
-    target = target / data_range * 255
+    x = x / data_range * 255
+    y = y / data_range * 255
 
     # Averaging image if the size is large enough
-    kernel_size = max(1, round(min(prediction.size()[-2:]) / 256))
+    kernel_size = max(1, round(min(x.size()[-2:]) / 256))
     padding = kernel_size // 2
 
     if padding:
         up_pad = (kernel_size - 1) // 2
         down_pad = padding
         pad_to_use = [up_pad, down_pad, up_pad, down_pad]
-        prediction = pad(prediction, pad=pad_to_use)
-        target = pad(target, pad=pad_to_use)
+        x = pad(x, pad=pad_to_use)
+        y = pad(y, pad=pad_to_use)
 
-    prediction = avg_pool2d(prediction, kernel_size=kernel_size)
-    target = avg_pool2d(target, kernel_size=kernel_size)
+    x = avg_pool2d(x, kernel_size=kernel_size)
+    y = avg_pool2d(y, kernel_size=kernel_size)
 
-    prediction_lhm = rgb2lhm(prediction)
-    target_lhm = rgb2lhm(target)
+    x_lhm = rgb2lhm(x)
+    y_lhm = rgb2lhm(y)
 
-    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(1, 2)]).to(prediction)
-    gm_prediction = gradient_map(prediction_lhm[:, :1], kernels)
-    gm_target = gradient_map(target_lhm[:, :1], kernels)
-    gm_avg = gradient_map((prediction_lhm[:, :1] + target_lhm[:, :1]) / 2., kernels)
+    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(1, 2)]).to(x)
+    gm_x = gradient_map(x_lhm[:, :1], kernels)
+    gm_y = gradient_map(y_lhm[:, :1], kernels)
+    gm_avg = gradient_map((x_lhm[:, :1] + y_lhm[:, :1]) / 2., kernels)
 
-    gs_prediction_target = similarity_map(gm_prediction, gm_target, c1)
-    gs_prediction_average = similarity_map(gm_prediction, gm_avg, c2)
-    gs_target_average = similarity_map(gm_target, gm_avg, c2)
+    gs_x_y = similarity_map(gm_x, gm_y, c1)
+    gs_x_average = similarity_map(gm_x, gm_avg, c2)
+    gs_y_average = similarity_map(gm_y, gm_avg, c2)
 
-    gs_total = gs_prediction_target + gs_prediction_average - gs_target_average
+    gs_total = gs_x_y + gs_x_average - gs_y_average
 
-    cs_total = (2 * (prediction_lhm[:, 1:2] * target_lhm[:, 1:2] +
-                     prediction_lhm[:, 2:] * target_lhm[:, 2:]) + c3) / (prediction_lhm[:, 1:2] ** 2 +
-                                                                         target_lhm[:, 1:2] ** 2 +
-                                                                         prediction_lhm[:, 2:] ** 2 +
-                                                                         target_lhm[:, 2:] ** 2 + c3)
+    cs_total = (2 * (x_lhm[:, 1:2] * y_lhm[:, 1:2] +
+                     x_lhm[:, 2:] * y_lhm[:, 2:]) + c3) / (x_lhm[:, 1:2] ** 2 +
+                                                                         y_lhm[:, 1:2] ** 2 +
+                                                                         x_lhm[:, 2:] ** 2 +
+                                                                         y_lhm[:, 2:] ** 2 + c3)
 
     if combination == 'sum':
         gcs = (alpha * gs_total + (1 - alpha) * cs_total)
@@ -113,8 +113,8 @@ def mdsi(prediction: torch.Tensor, target: torch.Tensor, data_range: Union[int, 
 
 
 class MDSILoss(_Loss):
-    r"""Creates a criterion that measures Mean Deviation Similarity Index (MDSI) error between the prediction and
-    target.
+    r"""Creates a criterion that measures Mean Deviation Similarity Index (MDSI) error between the prediction :math:`x`
+    and target :math:`y`.
 
     Args:
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
@@ -141,9 +141,9 @@ class MDSILoss(_Loss):
     Examples::
 
         >>> loss = MDSILoss(data_range=1.)
-        >>> prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-        >>> target = torch.rand(3, 3, 256, 256)
-        >>> output = loss(prediction, target)
+        >>> x = torch.rand(3, 3, 256, 256, requires_grad=True)
+        >>> y = torch.rand(3, 3, 256, 256)
+        >>> output = loss(x, y)
         >>> output.backward()
 
     References:
@@ -165,14 +165,17 @@ class MDSILoss(_Loss):
                                       combination=combination, beta=beta, gamma=gamma, data_range=self.data_range,
                                       reduction=self.reduction)
 
-    def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         r"""Computation of Mean Deviation Similarity Index (MDSI) as a loss function.
+
         Both inputs are supposed to have RGB channels order.
         Greyscale images converted to RGB by copying the grey channel 3 times.
 
         Args:
-            prediction: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
-            target: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
+            x: Predicted images set :math:`x`.
+                Shape (H, W), (C, H, W) or (N, C, H, W).
+            y: Target images set :math:`y`.
+                Shape (H, W), (C, H, W) or (N, C, H, W).
 
         Returns:
             Value of MDSI loss to be minimized. 0 <= MDSI loss <= 1.
@@ -182,4 +185,4 @@ class MDSILoss(_Loss):
             Nevertheless, the method supports greyscale images, which are converted to RGB by copying the grey
             channel 3 times.
         """
-        return 1. - torch.clamp(self.mdsi(prediction=prediction, target=target), min=0., max=1.)
+        return 1. - torch.clamp(self.mdsi(x=x, y=y), min=0., max=1.)

--- a/piq/msid.py
+++ b/piq/msid.py
@@ -256,15 +256,10 @@ def _normalize_msid(msid: np.ndarray, normalization: str, n: int, k: int, ts: np
     return normed_msid
 
 
-def _msid_descriptor(
-        x: np.ndarray,
-        ts: np.ndarray = np.logspace(-1, 1, 256),
-        k: int = 5,
-        m: int = 10,
-        niters: int = 100,
-        rademacher: bool = False,
-        normalized_laplacian: bool = True,
-        normalize: str = 'empty') -> np.ndarray:
+def _msid_descriptor(x: np.ndarray, ts: np.ndarray = np.logspace(-1, 1, 256), k: int = 5, m: int = 10,
+                     niters: int = 100, rademacher: bool = False, normalized_laplacian: bool = True,
+                     normalize: str = 'empty') \
+        -> np.ndarray:
     r"""Compute the msid descriptor for a single set of samples
 
     Args:
@@ -298,8 +293,10 @@ class MSID(BaseFeatureMetric):
     number of samples or different dimensionalities.
 
     Args:
-        predicted_features: Low-dimension representation of predicted image set. Shape (N_pred, encoder_dim)
-        target_features: Low-dimension representation of target image set. Shape (N_targ, encoder_dim)
+        x_features: Low-dimension representation of predicted image set `x`.
+            Shape (N_x, encoder_dim)
+        y_features: Low-dimension representation of target image set `y`.
+            Shape (N_y, encoder_dim)
 
     Returns:
         score: Scalar value of the distance between image sets features.
@@ -308,17 +305,9 @@ class MSID(BaseFeatureMetric):
         https://arxiv.org/abs/1905.11141
     """
 
-    def __init__(
-            self,
-            ts: torch.Tensor = torch.logspace(-1, 1, 256),
-            k: int = 5,
-            m: int = 10,
-            niters: int = 100,
-            rademacher: bool = False,
-            normalized_laplacian: bool = True,
-            normalize: str = 'empty',
-            msid_mode: str = "max",
-    ) -> None:
+    def __init__(self, ts: torch.Tensor = torch.logspace(-1, 1, 256), k: int = 5, m: int = 10, niters: int = 100,
+                 rademacher: bool = False, normalized_laplacian: bool = True, normalize: str = 'empty',
+                 msid_mode: str = "max") -> None:
         r"""
         Args:
             ts: Temperature values.
@@ -344,12 +333,12 @@ class MSID(BaseFeatureMetric):
         self.normalized_laplacian = normalized_laplacian
         self.normalize = normalize
 
-    def compute_metric(self, predicted_features: torch.Tensor, target_features: torch.Tensor) -> torch.Tensor:
+    def compute_metric(self, x_features: torch.Tensor, y_features: torch.Tensor) -> torch.Tensor:
 
         r"""Compute MSID score between two sets of samples.
         Args:
-            x: Samples from data distribution. Shape (N_samples, data_dim).
-            y: Samples from data distribution. Shape (N_samples, data_dim).
+            x_features: Samples from data distribution. Shape (N_samples, data_dim).
+            y_features: Samples from data distribution. Shape (N_samples, data_dim).
             ts: Temperature values.
             k: Number of neighbours for graph construction.
             m: Lanczos steps in SLQ.
@@ -365,8 +354,8 @@ class MSID(BaseFeatureMetric):
         Returns:
             score: Scalar value of the distance between distributions.
         """
-        normed_msid_pred = _msid_descriptor(
-            predicted_features.detach().cpu().numpy(),
+        normed_msid_x = _msid_descriptor(
+            x_features.detach().cpu().numpy(),
             ts=self.ts,
             k=self.k,
             m=self.m,
@@ -375,8 +364,8 @@ class MSID(BaseFeatureMetric):
             normalized_laplacian=self.normalized_laplacian,
             normalize=self.normalize
         )
-        normed_msid_target = _msid_descriptor(
-            target_features.detach().cpu().numpy(),
+        normed_msid_y = _msid_descriptor(
+            y_features.detach().cpu().numpy(),
             ts=self.ts,
             k=self.k,
             m=self.m,
@@ -388,10 +377,10 @@ class MSID(BaseFeatureMetric):
 
         c = np.exp(-2 * (self.ts + 1 / self.ts))
         if self.msid_mode == 'l2':
-            score = np.linalg.norm(normed_msid_pred - normed_msid_target)
+            score = np.linalg.norm(normed_msid_x - normed_msid_y)
         elif self.msid_mode == 'max':
-            score = np.amax(c * np.abs(normed_msid_pred - normed_msid_target))
+            score = np.amax(c * np.abs(normed_msid_x - normed_msid_y))
         else:
             raise ValueError('Mode must be in {`l2`, `max`}')
 
-        return torch.tensor(score, device=predicted_features.device)
+        return torch.tensor(score, device=x_features.device)

--- a/piq/perceptual.py
+++ b/piq/perceptual.py
@@ -145,20 +145,20 @@ class ContentLoss(_Loss):
         self.normalize_features = normalize_features
         self.reduction = reduction
 
-    def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-        r"""Computation of Content loss between feature representations of prediction and target tensors.
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        r"""Computation of Content loss between feature representations of prediction (x) and target (y) tensors.
         Args:
-            prediction: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
-            target: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+            x: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
+            y: Tensor with shape (H, W), (C, H, W) or (N, C, H, W).
         """
-        _validate_input(input_tensors=(prediction, target), allow_5d=False, allow_negative=True)
-        prediction, target = _adjust_dimensions(input_tensors=(prediction, target))
+        _validate_input(input_tensors=(x, y), allow_5d=False, allow_negative=True)
+        x, y = _adjust_dimensions(input_tensors=(x, y))
 
-        self.model.to(prediction)
-        prediction_features = self.get_features(prediction)
-        target_features = self.get_features(target)
+        self.model.to(x)
+        x_features = self.get_features(x)
+        y_features = self.get_features(y)
 
-        distances = self.compute_distance(prediction_features, target_features)
+        distances = self.compute_distance(x_features, y_features)
 
         # Scale distances, then average in spatial dimensions, then stack and sum in channels dimension
         loss = torch.cat([(d * w.to(d)).mean(dim=[2, 3]) for d, w in zip(distances, self.weights)], dim=1).sum(dim=1)
@@ -170,9 +170,9 @@ class ContentLoss(_Loss):
                 'sum': loss.sum
                 }[self.reduction](dim=0)
 
-    def compute_distance(self, prediction_features: torch.Tensor, target_features: torch.Tensor) -> torch.Tensor:
+    def compute_distance(self, x_features: torch.Tensor, y_features: torch.Tensor) -> torch.Tensor:
         r"""Take L2 or L1 distance between feature maps"""
-        return [self.distance(x, y) for x, y in zip(prediction_features, target_features)]
+        return [self.distance(x, y) for x, y in zip(x_features, y_features)]
 
     def get_features(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""
@@ -190,6 +190,7 @@ class ContentLoss(_Loss):
             x = module(x)
             if name in self.layers:
                 features.append(self.normalize(x) if self.normalize_features else x)
+
         return features
 
     def normalize(self, x: torch.Tensor) -> torch.Tensor:
@@ -245,11 +246,11 @@ class StyleLoss(ContentLoss):
            https://arxiv.org/abs/1801.03924
     """
 
-    def compute_distance(self, prediction_features: torch.Tensor, target_features: torch.Tensor):
+    def compute_distance(self, x_features: torch.Tensor, y_features: torch.Tensor):
         """Take L2 or L1 distance between Gram matrixes of feature maps"""
-        prediction_gram = [self.gram_matrix(x) for x in prediction_features]
-        target_gram = [self.gram_matrix(x) for x in target_features]
-        return [self.distance(x, y) for x, y in zip(prediction_gram, target_gram)]
+        x_gram = [self.gram_matrix(x) for x in x_features]
+        y_gram = [self.gram_matrix(x) for x in y_features]
+        return [self.distance(x, y) for x, y in zip(x_gram, y_gram)]
 
     def gram_matrix(self, x: torch.Tensor) -> torch.Tensor:
         r"""Compute Gram matrix for batch of features.
@@ -263,6 +264,7 @@ class StyleLoss(ContentLoss):
 
             # Add fake channel dimension
             gram.append(torch.mm(features, features.t()).unsqueeze(0))
+
         return torch.stack(gram)
 
 
@@ -337,17 +339,17 @@ class DISTS(ContentLoss):
                          replace_pooling=True, reduction=reduction,
                          mean=mean, std=std, normalize_features=False)
 
-    def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-        loss = super().forward(prediction, target)
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        loss = super().forward(x, y)
         return 1 - loss
 
-    def compute_distance(self, prediction_features: torch.Tensor, target_features: torch.Tensor) -> List[torch.Tensor]:
+    def compute_distance(self, x_features: torch.Tensor, y_features: torch.Tensor) -> List[torch.Tensor]:
         r"""Compute structure similarity between feature maps"""
         structure_distance, texture_distance = [], []
         # Small constant for numerical stability
         EPS = 1e-6
 
-        for x, y in zip(prediction_features, target_features):
+        for x, y in zip(x_features, y_features):
             x_mean = x.mean([2, 3], keepdim=True)
             y_mean = y.mean([2, 3], keepdim=True)
             structure_distance.append(similarity_map(x_mean, y_mean, constant=EPS))
@@ -374,4 +376,5 @@ class DISTS(ContentLoss):
             
         for name, child in module.named_children():
             module_output.add_module(name, self.replace_pooling(child))
+
         return module_output

--- a/piq/psnr.py
+++ b/piq/psnr.py
@@ -12,8 +12,10 @@ def psnr(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1.0,
     Supports both greyscale and color images with RGB channel order.
 
     Args:
-        x: Predicted images. Shape (H, W), (C, H, W) or (N, C, H, W).
-        y: Target images. Shape (H, W), (C, H, W) or (N, C, H, W).
+        x: Predicted images set :math:`x`.
+            Shape (H, W), (C, H, W) or (N, C, H, W).
+        y: Target images set :math:`y`.
+            Shape (H, W), (C, H, W) or (N, C, H, W).
         data_range: Value range of input images (usually 1.0 or 255). Default: 1.0
         reduction: Reduction over samples in batch: "mean"|"sum"|"none"
         convert_to_greyscale: Convert RGB image to YCbCr format and computes PSNR

--- a/piq/ssim.py
+++ b/piq/ssim.py
@@ -123,9 +123,9 @@ class SSIMLoss(_Loss):
 
     Examples::
         >>> loss = SSIMLoss()
-        >>> prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-        >>> target = torch.rand(3, 3, 256, 256)
-        >>> output = loss(prediction, target)
+        >>> x = torch.rand(3, 3, 256, 256, requires_grad=True)
+        >>> y = torch.rand(3, 3, 256, 256)
+        >>> output = loss(x, y)
         >>> output.backward()
 
     References:
@@ -152,21 +152,19 @@ class SSIMLoss(_Loss):
         self.k2 = k2
         self.data_range = data_range
 
-    def forward(self,
-                prediction: torch.Tensor,
-                target: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         r"""Computation of Structural Similarity (SSIM) index as a loss function.
 
         Args:
-            prediction: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
-            target: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            x: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            y: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
         Returns:
             Value of SSIM loss to be minimized, i.e 1 - `ssim`. 0 <= SSIM loss <= 1. In case of 5D input tensors,
             complex value is returned as a tensor of size 2.
         """
 
-        score = ssim(x=prediction, y=target, kernel_size=self.kernel_size, kernel_sigma=self.kernel_sigma,
+        score = ssim(x=x, y=y, kernel_size=self.kernel_size, kernel_sigma=self.kernel_sigma,
                      data_range=self.data_range, reduction=self.reduction, full=False, k1=self.k1, k2=self.k2)
         return torch.ones_like(score) - score
 
@@ -337,21 +335,21 @@ class MultiScaleSSIMLoss(_Loss):
         self.k2 = k2
         self.data_range = data_range
 
-    def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         r"""Computation of Multi-scale Structural Similarity (MS-SSIM) index as a loss function.
         The size of the image should be at least (kernel_size - 1) * 2 ** (levels - 1) + 1.
         For colour images channel order is RGB.
 
         Args:
-            prediction: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
-            target: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            x: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
+            y: Tensor with shape 2D (H, W), 3D (C, H, W), 4D (N, C, H, W) or 5D (N, C, H, W, 2).
 
         Returns:
             Value of MS-SSIM loss to be minimized, i.e. 1-`ms_sim`. 0 <= MS-SSIM loss <= 1. In case of 5D tensor,
             complex value is returned as a tensor of size 2.
         """
 
-        score = multi_scale_ssim(x=prediction, y=target, kernel_size=self.kernel_size, kernel_sigma=self.kernel_sigma,
+        score = multi_scale_ssim(x=x, y=y, kernel_size=self.kernel_size, kernel_sigma=self.kernel_sigma,
                                  data_range=self.data_range, reduction=self.reduction, scale_weights=self.scale_weights,
                                  k1=self.k1, k2=self.k2)
         return torch.ones_like(score) - score

--- a/piq/tv.py
+++ b/piq/tv.py
@@ -79,32 +79,31 @@ class TVLoss(_Loss):
     Examples::
 
         >>> loss = TVLoss()
-        >>> prediction = torch.rand(3, 3, 256, 256, requires_grad=True)
-        >>> output = loss(prediction)
+        >>> x = torch.rand(3, 3, 256, 256, requires_grad=True)
+        >>> output = loss(x)
         >>> output.backward()
 
     References:
         https://www.wikiwand.com/en/Total_variation_denoising
         https://remi.flamary.com/demos/proxtv.html
     """
-
     def __init__(self, norm_type: str = 'l2', reduction: str = 'mean'):
         super().__init__()
 
         self.norm_type = norm_type
         self.reduction = reduction
 
-    def forward(self, prediction: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         r"""Computation of Total Variation (TV) index as a loss function.
 
         Args:
-            prediction: Tensor of prediction of the network.
+            x: Tensor of prediction of the network.
 
         Returns:
             Value of TV loss to be minimized.
         """
         score = total_variation(
-            prediction,
+            x,
             reduction=self.reduction,
             norm_type=self.norm_type,
         )

--- a/piq/utils/common.py
+++ b/piq/utils/common.py
@@ -72,15 +72,15 @@ def _validate_features(x: torch.Tensor, y: torch.Tensor) -> None:
     r"""Check, that computed features satisfy metric requirements.
 
     Args:
-        x : Low-dimensional representation of predicted images.
-        y : Low-dimensional representation of target images.
+        x : Low-dimensional representation of images :math:`x`.
+        y : Low-dimensional representation of images :math:`y`.
     """
     assert torch.is_tensor(x) and torch.is_tensor(y), \
         f"Both features should be torch.Tensors, got {type(x)} and {type(y)}"
     assert x.dim() == 2, \
-        f"Predicted features must have shape (N_samples, encoder_dim), got {x.shape}"
+        f"x features must have shape (N_samples, encoder_dim), got {x.shape}"
     assert y.dim() == 2, \
-        f"Target features must have shape  (N_samples, encoder_dim), got {y.shape}"
+        f"y features must have shape  (N_samples, encoder_dim), got {y.shape}"
     assert x.size(1) == y.size(1), \
         f"Features dimensionalities should match, otherwise it won't be possible to correctly compute statistics. \
             Got {x.size(1)} and {y.size(1)}"

--- a/piq/vif.py
+++ b/piq/vif.py
@@ -29,7 +29,7 @@ def vif_p(x: torch.Tensor, y: torch.Tensor, sigma_n_sq: float = 2.0,
         
     Returns:
         VIF: Index of similarity betwen two images. Usually in [0, 1] interval.
-            Can be bigger than 1 for predicted images with higher contrast than original one.
+            Can be bigger than 1 for predicted (x) images with higher contrast than original one.
     Note:
         In original paper this method was used for bands in discrete wavelet decomposition.
         Later on authors released code to compute VIF approximation in pixel domain.
@@ -115,7 +115,7 @@ def vif_p(x: torch.Tensor, y: torch.Tensor, sigma_n_sq: float = 2.0,
 
 class VIFLoss(_Loss):
     r"""Creates a criterion that measures the Visual Information Fidelity loss
-    between predicted and target image. In order to be considered as a loss,
+    between predicted (x) and target (y) image. In order to be considered as a loss,
     value `1 - clip(VIF, min=0, max=1)` is returned.
     """
 
@@ -142,8 +142,7 @@ class VIFLoss(_Loss):
             Value of VIF loss to be minimized. 0 <= VIFLoss <= 1.
         """
         # All checks are done in vif_p function
-        score = vif_p(
-            x, y, sigma_n_sq=self.sigma_n_sq, data_range=self.data_range, reduction=self.reduction)
+        score = vif_p(x, y, sigma_n_sq=self.sigma_n_sq, data_range=self.data_range, reduction=self.reduction)
 
         # Make sure value to be in [0, 1] range and convert to loss
         loss = 1 - torch.clamp(score, 0, 1)

--- a/piq/vsi.py
+++ b/piq/vsi.py
@@ -71,9 +71,9 @@ def vsi(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean', data_range: U
     y = y * 255. / data_range
 
     vs_x = sdsp(x, data_range=255, omega_0=omega_0,
-                         sigma_f=sigma_f, sigma_d=sigma_d, sigma_c=sigma_c)
+                sigma_f=sigma_f, sigma_d=sigma_d, sigma_c=sigma_c)
     vs_y = sdsp(y, data_range=255, omega_0=omega_0, sigma_f=sigma_f,
-                     sigma_d=sigma_d, sigma_c=sigma_c)
+                sigma_d=sigma_d, sigma_c=sigma_c)
 
     # Convert to LMN colour space
     x_lmn = rgb2lmn(x)
@@ -173,6 +173,7 @@ class VSILoss(_Loss):
            https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf,
            DOI:`10.1109/TIP.2003.819861`
     """
+
     def __init__(self, reduction: str = 'mean', c1: float = 1.27, c2: float = 386., c3: float = 130.,
                  alpha: float = 0.4, beta: float = 0.02, data_range: Union[int, float] = 1.,
                  omega_0: float = 0.021, sigma_f: float = 1.34, sigma_d: float = 145., sigma_c: float = 0.001) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,23 +14,23 @@ def device(request: Any) -> Any:
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(4, 3, 96, 96)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(4, 3, 96, 96)
 
 
-prediction_tensors = [
+x_tensors = [
     torch.rand(4, 3, 96, 96),  # Random 4D
     torch.rand(3, 96, 96),  # Random 3D
     torch.rand(4, 1, 96, 96),  # Random 4D greyscale
     torch.rand(96, 96),  # Random 2D greyscale
 ]
 
-target_tensors = [
+y_tensors = [
     torch.rand(4, 3, 96, 96),  # Random 4D
     torch.rand(3, 96, 96),  # Random 3D
     torch.rand(4, 1, 96, 96),  # Random 4D greyscale
@@ -38,6 +38,6 @@ target_tensors = [
 ]
 
 
-@pytest.fixture(params=zip(prediction_tensors, target_tensors))
+@pytest.fixture(params=zip(x_tensors, y_tensors))
 def input_tensors(request: Any) -> Any:
     return request.param

--- a/tests/test_fid.py
+++ b/tests/test_fid.py
@@ -27,23 +27,23 @@ class TestDataset(torch.utils.data.Dataset):
 
 
 @pytest.fixture(scope='module')
-def features_target_normal() -> torch.Tensor:
+def features_y_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_normal() -> torch.Tensor:
+def features_x_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_beta() -> torch.Tensor:
+def features_x_beta() -> torch.Tensor:
     m = torch.distributions.Beta(torch.FloatTensor([2]), torch.FloatTensor([2]))
     return m.sample([1000, 20]).squeeze()
 
 
 @pytest.fixture(scope='module')
-def features_prediction_constant() -> torch.Tensor:
+def features_x_constant() -> torch.Tensor:
     return torch.ones(1000, 20)
 
 
@@ -52,9 +52,9 @@ def test_initialization() -> None:
     FID()
 
 
-def test_forward(features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor, device: str) -> None:
+def test_forward(features_y_normal, features_x_normal, device: str) -> None:
     fid = FID()
-    fid(features_target_normal.to(device), features_prediction_normal.to(device))
+    fid(features_y_normal.to(device), features_x_normal.to(device))
 
 
 def test_compute_feats(device: str) -> None:

--- a/tests/test_fsim.py
+++ b/tests/test_fsim.py
@@ -13,35 +13,35 @@ def raise_nothing():
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(3, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(3, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def prediction_grey() -> torch.Tensor:
+def x_grey() -> torch.Tensor:
     return torch.rand(3, 1, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def target_grey() -> torch.Tensor:
+def y_grey() -> torch.Tensor:
     return torch.rand(3, 1, 256, 256)
 
 
 # ================== Test function: `fsim` ==================
 def test_fsim_forward(input_tensors, device: str) -> None:
-    prediction, target = input_tensors
-    fsim(prediction.to(device), target.to(device), chromatic=False)
+    x, y = input_tensors
+    fsim(x.to(device), y.to(device), chromatic=False)
 
 
 @pytest.mark.parametrize("chromatic", [False, True])
-def test_fsim_symmetry(prediction: torch.Tensor, target: torch.Tensor, chromatic: bool, device: str) -> None:
-    measure = fsim(prediction.to(device), target.to(device), data_range=1., chromatic=chromatic)
-    reverse_measure = fsim(target.to(device), prediction.to(device), data_range=1., chromatic=chromatic)
+def test_fsim_symmetry(x, y, chromatic: bool, device: str) -> None:
+    measure = fsim(x.to(device), y.to(device), data_range=1., chromatic=chromatic)
+    reverse_measure = fsim(y.to(device), x.to(device), data_range=1., chromatic=chromatic)
     assert (measure == reverse_measure).all(), f'Expect: FSIM(a, b) == FSIM(b, a), got {measure} != {reverse_measure}'
 
 
@@ -49,10 +49,9 @@ def test_fsim_symmetry(prediction: torch.Tensor, target: torch.Tensor, chromatic
     "chromatic,expectation",
     [(False, raise_nothing()),
      (True, pytest.raises(AssertionError))])
-def test_fsim_chromatic_raises_for_greyscale(
-        prediction_grey: torch.Tensor, target_grey: torch.Tensor, chromatic: bool, expectation: Any) -> None:
+def test_fsim_chromatic_raises_for_greyscale(x_grey, y_grey, chromatic: bool, expectation: Any) -> None:
     with expectation:
-        fsim(prediction_grey, target_grey, data_range=1., chromatic=chromatic)
+        fsim(x_grey, y_grey, data_range=1., chromatic=chromatic)
 
 
 @pytest.mark.parametrize(
@@ -78,26 +77,25 @@ def test_fsim_for_special_cases(x: torch.Tensor, y: torch.Tensor, expectation: A
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_fsim_supports_different_data_ranges(
-        prediction: torch.Tensor, target: torch.Tensor, data_range, device: str) -> None:
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
-    measure_scaled = fsim(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+def test_fsim_supports_different_data_ranges(x, y, data_range, device: str) -> None:
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
+    measure_scaled = fsim(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = fsim(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-5, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_fsim_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_fsim_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        fsim(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        fsim(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
         
 
 def test_fsim_simmular_to_matlab_implementation():
@@ -130,27 +128,27 @@ def test_fsim_simmular_to_matlab_implementation():
 
 
 # ================== Test class: `FSIMLoss` ==================
-def test_fsim_loss_reduction(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_fsim_loss_reduction(x, y) -> None:
     loss = FSIMLoss(reduction='mean')
-    measure = loss(prediction, target)
+    measure = loss(x, y)
     assert measure.dim() == 0, f'FSIM with `mean` reduction must return 1 number, got {len(measure)}'
 
     loss = FSIMLoss(reduction='sum')
-    measure = loss(prediction, target)
+    measure = loss(x, y)
     assert measure.dim() == 0, f'FSIM with `mean` reduction must return 1 number, got {len(measure)}'
 
     loss = FSIMLoss(reduction='none')
-    measure = loss(prediction, target)
-    assert len(measure) == prediction.size(0), \
+    measure = loss(x, y)
+    assert len(measure) == x.size(0), \
         f'FSIM with `none` reduction must have length equal to number of images, got {len(measure)}'
     
     loss = FSIMLoss(reduction='random string')
     with pytest.raises(KeyError):
-        loss(prediction, target)
+        loss(x, y)
 
 
-def test_fsim_loss_computes_grad(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = FSIMLoss()(prediction.to(device), target.to(device))
+def test_fsim_loss_computes_grad(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = FSIMLoss()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, 'Expected non None gradient of leaf variable'
+    assert x.grad is not None, 'Expected non None gradient of leaf variable'

--- a/tests/test_gmsd.py
+++ b/tests/test_gmsd.py
@@ -10,138 +10,135 @@ LEAF_VARIABLE_ERROR_MESSAGE = 'Expected non None gradient of leaf variable'
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(2, 3, 96, 96)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(2, 3, 96, 96)
 
-
-prediction_image = [
+x_image = [
     torch.tensor(imread('tests/assets/goldhill_jpeg.gif'), dtype=torch.float32).unsqueeze(0).unsqueeze(0),
     torch.tensor(imread('tests/assets/i01_01_5.bmp'), dtype=torch.float32).permute(2, 0, 1).unsqueeze(0)
 ]
 
-target_image = [
+y_image = [
     torch.tensor(imread('tests/assets/goldhill.gif'), dtype=torch.float32).unsqueeze(0).unsqueeze(0),
     torch.tensor(imread('tests/assets/I01.BMP'), dtype=torch.float32).permute(2, 0, 1).unsqueeze(0)
 ]
-target_score = [
+
+y_score = [
     torch.tensor(0.138012587141798),
     torch.tensor(0.094124655829098)
 ]
 
 
-@pytest.fixture(params=zip(prediction_image, target_image, target_score))
+@pytest.fixture(params=zip(x_image, y_image, y_score))
 def input_images_score(request: Any) -> Any:
     return request.param
 
 
 # ================== Test function: `gmsd` ==================
-def test_gmsd_forward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    gmsd(prediction.to(device), target.to(device))
+def test_gmsd_forward(x, y, device: str) -> None:
+    gmsd(x.to(device), y.to(device))
 
 
-def test_gmsd_zero_for_equal_tensors(prediction: torch.Tensor, device: str) -> None:
-    target = prediction.clone()
-    measure = gmsd(prediction.to(device), target.to(device))
+def test_gmsd_zero_for_equal_tensors(x, device: str) -> None:
+    y = x.clone()
+    measure = gmsd(x.to(device), y.to(device))
     assert measure.abs() <= 1e-6, f'GMSD for equal tensors must be 0, got {measure}'
 
 
-def test_gmsd_raises_if_tensors_have_different_types(target: torch.Tensor, device: str) -> None:
-    wrong_type_predictions = [list(range(10)), np.arange(10)]
-    for wrong_type_prediction in wrong_type_predictions:
+def test_gmsd_raises_if_tensors_have_different_types(y, device: str) -> None:
+    wrong_type_x = [list(range(10)), np.arange(10)]
+    for wrong_type_x in wrong_type_x:
         with pytest.raises(AssertionError):
-            gmsd(wrong_type_prediction, target.to(device))
+            gmsd(wrong_type_x, y.to(device))
 
 
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_gmsd_supports_different_data_ranges(
-        prediction: torch.Tensor, target: torch.Tensor, data_range, device: str) -> None:
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
-    measure_scaled = gmsd(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+def test_gmsd_supports_different_data_ranges(x, y, data_range, device: str) -> None:
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
+    measure_scaled = gmsd(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = gmsd(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_gmsd_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_gmsd_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        gmsd(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        gmsd(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
         
 
 def test_gmsd_supports_greyscale_tensors(device: str) -> None:
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
-    gmsd(prediction.to(device), target.to(device))
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
+    gmsd(x.to(device), y.to(device))
 
 
-def test_gmsd_modes(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_gmsd_modes(x, y, device: str) -> None:
     for reduction in ['mean', 'sum', 'none']:
-        gmsd(prediction.to(device), target.to(device), reduction=reduction)
+        gmsd(x.to(device), y.to(device), reduction=reduction)
 
     for reduction in ['DEADBEEF', 'random']:
         with pytest.raises(KeyError):
-            gmsd(prediction.to(device), target.to(device), reduction=reduction)
+            gmsd(x.to(device), y.to(device), reduction=reduction)
 
 
 def test_gmsd_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
                                   device: str) -> None:
-    prediction, target, target_value = input_images_score
-    score = gmsd(prediction=prediction.to(device), target=target.to(device), data_range=255)
-    assert torch.isclose(score, target_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
-                                                         f'got {score.item():.8f}, while MATLAB equals {target_value}'
+    x, y, y_value = input_images_score
+    score = gmsd(x=x.to(device), y=y.to(device), data_range=255)
+    assert torch.isclose(score, y_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
+                                                         f'got {score.item():.8f}, while MATLAB equals {y_value}'
 
 
 # ================== Test class: `GMSDLoss` ==================
-def test_gmsd_loss_forward_backward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = GMSDLoss()(prediction.to(device), target.to(device))
+def test_gmsd_loss_forward_backward(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = GMSDLoss()(x.to(device), y.to(device))
     loss_value.backward()
-    assert torch.isfinite(prediction.grad).all(), LEAF_VARIABLE_ERROR_MESSAGE
+    assert torch.isfinite(x.grad).all(), LEAF_VARIABLE_ERROR_MESSAGE
 
 
-def test_gmsd_loss_zero_for_equal_tensors(prediction: torch.Tensor, device: str) -> None:
+def test_gmsd_loss_zero_for_equal_tensors(x, device: str) -> None:
     loss = GMSDLoss()
-    target = prediction.clone()
-    measure = loss(prediction.to(device), target.to(device))
+    y = x.clone()
+    measure = loss(x.to(device), y.to(device))
     assert measure.abs() <= 1e-6, f'GMSD for equal tensors must be 0, got {measure}'
 
 
-def test_gmsd_loss_raises_if_tensors_have_different_types(target: torch.Tensor, device: str) -> None:
-    wrong_type_predictions = [list(range(10)), np.arange(10)]
-    for wrong_type_prediction in wrong_type_predictions:
+def test_gmsd_loss_raises_if_tensors_have_different_types(y, device: str) -> None:
+    wrong_type_x = [list(range(10)), np.arange(10)]
+    for wrong_x in wrong_type_x:
         with pytest.raises(AssertionError):
-            GMSDLoss()(wrong_type_prediction, target.to(device))
+            GMSDLoss()(wrong_x, y.to(device))
 
 
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_gmsd_loss_supports_different_data_ranges(
-        prediction: torch.Tensor, target: torch.Tensor, data_range, device: str) -> None:
-
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+def test_gmsd_loss_supports_different_data_ranges(x, y, data_range, device: str) -> None:
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
     loss_scaled = GMSDLoss(data_range=data_range)
-    measure_scaled = loss_scaled(prediction_scaled.to(device), target_scaled.to(device))
+    measure_scaled = loss_scaled(x_scaled.to(device), y_scaled.to(device))
 
     loss = GMSDLoss()
     measure = loss(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
@@ -149,154 +146,149 @@ def test_gmsd_loss_supports_different_data_ranges(
 
 def test_gmsd_loss_supports_greyscale_tensors(device: str) -> None:
     loss = GMSDLoss()
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
-    loss(prediction.to(device), target.to(device))
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
+    loss(x.to(device), y.to(device))
 
 
-def test_gmsd_loss_modes(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_gmsd_loss_modes(x, y, device: str) -> None:
     for reduction in ['mean', 'sum', 'none']:
-        GMSDLoss(reduction=reduction)(prediction.to(device), target.to(device))
+        GMSDLoss(reduction=reduction)(x.to(device), y.to(device))
 
     for reduction in ['DEADBEEF', 'random']:
         with pytest.raises(KeyError):
-            GMSDLoss(reduction=reduction)(prediction.to(device), target.to(device))
+            GMSDLoss(reduction=reduction)(x.to(device), y.to(device))
 
 
 # ================== Test function: `multi_scale_gmsd` ==================
-def test_multi_scale_gmsd_forward_backward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    multi_scale_gmsd(prediction.to(device), target.to(device), chromatic=True)
+def test_multi_scale_gmsd_forward_backward(x, y, device: str) -> None:
+    multi_scale_gmsd(x.to(device), y.to(device), chromatic=True)
 
 
-def test_multi_scale_gmsd_zero_for_equal_tensors(prediction: torch.Tensor, device: str) -> None:
-    target = prediction.clone()
-    measure = multi_scale_gmsd(prediction.to(device), target.to(device))
+def test_multi_scale_gmsd_zero_for_equal_tensors(x, device: str) -> None:
+    y = x.clone()
+    measure = multi_scale_gmsd(x.to(device), y.to(device))
     assert measure.abs() <= 1e-6, f'MultiScaleGMSD for equal tensors must be 0, got {measure}'
 
 
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_multi_scale_gmsd_supports_different_data_ranges(
-        prediction: torch.Tensor, target: torch.Tensor, data_range, device: str) -> None:
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
-    measure_scaled = multi_scale_gmsd(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+def test_multi_scale_gmsd_supports_different_data_ranges(x, y, data_range, device: str) -> None:
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
+    measure_scaled = multi_scale_gmsd(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = multi_scale_gmsd(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_multi_scale_gmsd_fails_for_incorrect_data_range(
-        prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_multi_scale_gmsd_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        multi_scale_gmsd(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        multi_scale_gmsd(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
 
 
 def test_multi_scale_gmsd_supports_greyscale_tensors(device: str) -> None:
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
-    multi_scale_gmsd(prediction.to(device), target.to(device))
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
+    multi_scale_gmsd(x.to(device), y.to(device))
 
 
 def test_multi_scale_gmsd_fails_for_greyscale_tensors_chromatic_flag(device: str) -> None:
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
     with pytest.raises(AssertionError):
-        multi_scale_gmsd(prediction.to(device), target.to(device), chromatic=True)
+        multi_scale_gmsd(x.to(device), y.to(device), chromatic=True)
 
 
-def test_multi_scale_gmsd_supports_custom_weights(prediction: torch.Tensor, target: torch.Tensor,
-                                                  device: str) -> None:
-    multi_scale_gmsd(prediction.to(device), target.to(device), scale_weights=[3., 4., 2., 1., 2.])
-    multi_scale_gmsd(prediction.to(device), target.to(device), scale_weights=torch.tensor([3., 4., 2., 1., 2.]))
+def test_multi_scale_gmsd_supports_custom_weights(x, y, device: str) -> None:
+    multi_scale_gmsd(x.to(device), y.to(device), scale_weights=[3., 4., 2., 1., 2.])
+    multi_scale_gmsd(x.to(device), y.to(device), scale_weights=torch.tensor([3., 4., 2., 1., 2.]))
 
 
 def test_multi_scale_gmsd_raise_exception_for_small_images(device: str) -> None:
-    target = torch.ones(3, 1, 32, 32)
-    prediction = torch.zeros(3, 1, 32, 32)
+    y = torch.ones(3, 1, 32, 32)
+    x = torch.zeros(3, 1, 32, 32)
     with pytest.raises(ValueError):
-        multi_scale_gmsd(prediction.to(device), target.to(device), scale_weights=[3., 4., 2., 1., 1.])
+        multi_scale_gmsd(x.to(device), y.to(device), scale_weights=[3., 4., 2., 1., 1.])
 
 
-def test_multi_scale_gmsd_modes(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_multi_scale_gmsd_modes(x, y, device: str) -> None:
     for reduction in ['mean', 'sum', 'none']:
-        multi_scale_gmsd(prediction.to(device), target.to(device), reduction=reduction)
+        multi_scale_gmsd(x.to(device), y.to(device), reduction=reduction)
 
     for reduction in ['DEADBEEF', 'random']:
         with pytest.raises(KeyError):
-            multi_scale_gmsd(prediction.to(device), target.to(device), reduction=reduction)
+            multi_scale_gmsd(x.to(device), y.to(device), reduction=reduction)
 
 
 # ================== Test class: `MultiScaleGMSDLoss` ==================
-def test_multi_scale_gmsd_loss_forward_backward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = MultiScaleGMSDLoss(chromatic=True)(prediction.to(device), target.to(device))
+def test_multi_scale_gmsd_loss_forward_backward(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = MultiScaleGMSDLoss(chromatic=True)(x.to(device), y.to(device))
     loss_value.backward()
-    assert torch.isfinite(prediction.grad).all(), LEAF_VARIABLE_ERROR_MESSAGE
+    assert torch.isfinite(x.grad).all(), LEAF_VARIABLE_ERROR_MESSAGE
     
 
-def test_multi_scale_gmsd_loss_zero_for_equal_tensors(prediction: torch.Tensor, device: str) -> None:
+def test_multi_scale_gmsd_loss_zero_for_equal_tensors(x, device: str) -> None:
     loss = MultiScaleGMSDLoss()
-    target = prediction.clone()
-    measure = loss(prediction.to(device), target.to(device))
+    y = x.clone()
+    measure = loss(x.to(device), y.to(device))
     assert measure.abs() <= 1e-6, f'MultiScaleGMSD for equal tensors must be 0, got {measure}'
 
 
-def test_multi_scale_gmsd_loss_supports_different_data_ranges(prediction: torch.Tensor, target: torch.Tensor,
-                                                              device: str) -> None:
-    prediction_255 = prediction * 255
-    target_255 = target * 255
+def test_multi_scale_gmsd_loss_supports_different_data_ranges(x, y, device: str) -> None:
+    x_255 = x * 255
+    y_255 = y * 255
     loss = MultiScaleGMSDLoss()
-    measure = loss(prediction.to(device), target.to(device))
+    measure = loss(x.to(device), y.to(device))
     loss_255 = MultiScaleGMSDLoss(data_range=255)
-    measure_255 = loss_255(prediction_255.to(device), target_255.to(device))
+    measure_255 = loss_255(x_255.to(device), y_255.to(device))
     diff = torch.abs(measure_255 - measure)
     assert diff <= 1e-4, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
 def test_multi_scale_gmsd_loss_supports_greyscale_tensors(device: str) -> None:
     loss = MultiScaleGMSDLoss()
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
-    loss(prediction.to(device), target.to(device))
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
+    loss(x.to(device), y.to(device))
 
 
 def test_multi_scale_gmsd_loss_fails_for_greyscale_tensors_chromatic_flag(device: str) -> None:
     loss = MultiScaleGMSDLoss(chromatic=True)
-    target = torch.ones(2, 1, 96, 96)
-    prediction = torch.zeros(2, 1, 96, 96)
+    y = torch.ones(2, 1, 96, 96)
+    x = torch.zeros(2, 1, 96, 96)
     with pytest.raises(AssertionError):
-        loss(prediction.to(device), target.to(device))
+        loss(x.to(device), y.to(device))
 
 
-def test_multi_scale_gmsd_loss_supports_custom_weights(prediction: torch.Tensor, target: torch.Tensor,
-                                                       device: str) -> None:
+def test_multi_scale_gmsd_loss_supports_custom_weights(x, y, device: str) -> None:
     loss = MultiScaleGMSDLoss(scale_weights=[3., 4., 2., 1., 2.])
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
     loss = MultiScaleGMSDLoss(scale_weights=torch.tensor([3., 4., 2., 1., 2.]))
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
 def test_multi_scale_gmsd_loss_raise_exception_for_small_images(device: str) -> None:
-    target = torch.ones(3, 1, 32, 32)
-    prediction = torch.zeros(3, 1, 32, 32)
+    y = torch.ones(3, 1, 32, 32)
+    x = torch.zeros(3, 1, 32, 32)
     loss = MultiScaleGMSDLoss(scale_weights=[3., 4., 2., 1., 1.])
     with pytest.raises(ValueError):
-        loss(prediction.to(device), target.to(device))
+        loss(x.to(device), y.to(device))
 
 
-def test_multi_scale_loss_gmsd_modes(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_multi_scale_loss_gmsd_modes(x, y, device: str) -> None:
     for reduction in ['mean', 'sum', 'none']:
-        MultiScaleGMSDLoss(reduction=reduction)(prediction.to(device), target.to(device))
+        MultiScaleGMSDLoss(reduction=reduction)(x.to(device), y.to(device))
 
     for reduction in ['DEADBEEF', 'random']:
         with pytest.raises(KeyError):
-            MultiScaleGMSDLoss(reduction=reduction)(prediction.to(device), target.to(device))
+            MultiScaleGMSDLoss(reduction=reduction)(x.to(device), y.to(device))

--- a/tests/test_gmsd.py
+++ b/tests/test_gmsd.py
@@ -18,6 +18,7 @@ def x() -> torch.Tensor:
 def y() -> torch.Tensor:
     return torch.rand(2, 3, 96, 96)
 
+
 x_image = [
     torch.tensor(imread('tests/assets/goldhill_jpeg.gif'), dtype=torch.float32).unsqueeze(0).unsqueeze(0),
     torch.tensor(imread('tests/assets/i01_01_5.bmp'), dtype=torch.float32).permute(2, 0, 1).unsqueeze(0)
@@ -79,7 +80,7 @@ def test_gmsd_fails_for_incorrect_data_range(x, y, device: str) -> None:
     y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
         gmsd(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
-        
+
 
 def test_gmsd_supports_greyscale_tensors(device: str) -> None:
     y = torch.ones(2, 1, 96, 96)
@@ -101,7 +102,7 @@ def test_gmsd_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.
     x, y, y_value = input_images_score
     score = gmsd(x=x.to(device), y=y.to(device), data_range=255)
     assert torch.isclose(score, y_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
-                                                         f'got {score.item():.8f}, while MATLAB equals {y_value}'
+                                                    f'got {score.item():.8f}, while MATLAB equals {y_value}'
 
 
 # ================== Test class: `GMSDLoss` ==================
@@ -235,7 +236,7 @@ def test_multi_scale_gmsd_loss_forward_backward(x, y, device: str) -> None:
     loss_value = MultiScaleGMSDLoss(chromatic=True)(x.to(device), y.to(device))
     loss_value.backward()
     assert torch.isfinite(x.grad).all(), LEAF_VARIABLE_ERROR_MESSAGE
-    
+
 
 def test_multi_scale_gmsd_loss_zero_for_equal_tensors(x, device: str) -> None:
     loss = MultiScaleGMSDLoss()

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -5,17 +5,17 @@ from piq import GS
 
 
 @pytest.fixture(scope='module')
-def features_target_normal() -> torch.Tensor:
+def features_y_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_normal() -> torch.Tensor:
+def features_x_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_beta() -> torch.Tensor:
+def features_x_beta() -> torch.Tensor:
     m = torch.distributions.Beta(torch.FloatTensor([2]), torch.FloatTensor([2]))
     return m.sample([1000, 20]).squeeze()
 
@@ -28,28 +28,25 @@ def test_initialization() -> None:
         pytest.fail(f"Unexpected error occurred: {e}")
 
 
-def test_forward(
-        features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor,) -> None:
+def test_forward(features_y_normal, features_x_normal,) -> None:
     try:
         metric = GS(num_iters=10, sample_size=8)
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
     except Exception as e:
         pytest.fail(f"Unexpected error occurred: {e}")
 
 
 @pytest.mark.skip(reason="Randomnly fails, fix in separate PR")
-def test_similar_for_same_distribution(
-        features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor) -> None:
+def test_similar_for_same_distribution(features_y_normal, features_x_normal) -> None:
     metric = GS(sample_size=1000, num_iters=100, i_max=1000, num_workers=4)
-    diff = metric(features_prediction_normal, features_target_normal)
+    diff = metric(features_x_normal, features_y_normal)
     assert diff <= 2.0, \
         f'For same distributions GS should be small, got {diff}'
 
 
 @pytest.mark.skip(reason="Randomnly fails, fix in separate PR")
-def test_differs_for_not_simular_distributions(
-        features_prediction_beta: torch.Tensor, features_target_normal: torch.Tensor) -> None:
+def test_differs_for_not_simular_distributions(features_x_beta, features_y_normal) -> None:
     metric = GS(sample_size=1000, num_iters=100, i_max=1000, num_workers=4)
-    diff = metric(features_prediction_beta, features_target_normal)
+    diff = metric(features_x_beta, features_y_normal)
     assert diff >= 5.0, \
         f'For different distributions GS diff should be big, got {diff}'

--- a/tests/test_haarpsi.py
+++ b/tests/test_haarpsi.py
@@ -7,9 +7,9 @@ from typing import Tuple
 
 # ================== Test function: `haarpsi` ==================
 def test_haarpsi_to_be_one_for_identical_inputs(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, _ = input_tensors
-    index = haarpsi(prediction.to(device), prediction.to(device), data_range=1., reduction='none')
-    index_255 = haarpsi(prediction.to(device) * 255, prediction.to(device) * 255, data_range=255, reduction='none')
+    x, _ = input_tensors
+    index = haarpsi(x.to(device), x.to(device), data_range=1., reduction='none')
+    index_255 = haarpsi(x.to(device) * 255, x.to(device) * 255, data_range=255, reduction='none')
     assert torch.allclose(index, torch.ones_like(index, device=device), atol=1e-5), \
         f'Expected index to be equal 1, got {index}'
     assert torch.allclose(index_255, torch.ones_like(index_255, device=device), atol=1e-5), \
@@ -17,9 +17,9 @@ def test_haarpsi_to_be_one_for_identical_inputs(input_tensors: Tuple[torch.Tenso
 
 
 def test_haarpsi_symmetry(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    result = haarpsi(prediction.to(device), target.to(device), data_range=1., reduction='none')
-    result_sym = haarpsi(target.to(device), prediction.to(device), data_range=1., reduction='none')
+    x, y = input_tensors
+    result = haarpsi(x.to(device), y.to(device), data_range=1., reduction='none')
+    result_sym = haarpsi(y.to(device), x.to(device), data_range=1., reduction='none')
     assert torch.allclose(result_sym, result), f'Expected the same results, got {result} and {result_sym}'
 
 
@@ -34,10 +34,10 @@ def test_haarpsi_zeros_ones_inputs(device: str) -> None:
 
 
 def test_haarpsi_small_input(device: str) -> None:
-    prediction = torch.rand(1, 3, 10, 10, device=device)
-    target = torch.rand(1, 3, 10, 10, device=device)
+    x = torch.rand(1, 3, 10, 10, device=device)
+    y = torch.rand(1, 3, 10, 10, device=device)
     with pytest.raises(ValueError):
-        haarpsi(prediction, target, data_range=1.)
+        haarpsi(x, y, data_range=1.)
 
 
 @pytest.mark.parametrize(
@@ -45,32 +45,32 @@ def test_haarpsi_small_input(device: str) -> None:
 )
 def test_haarpsi_supports_different_data_ranges(
         input_tensors: Tuple[torch.Tensor, torch.Tensor], data_range, device: str) -> None:
-    prediction, target = input_tensors
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+    x, y = input_tensors
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
 
-    measure_scaled = haarpsi(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+    measure_scaled = haarpsi(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = haarpsi(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_haarpsi_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_haarpsi_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        haarpsi(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        haarpsi(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
 
 
 def test_haarpsi_compare_with_matlab(device: str) -> None:
-    prediction = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1)
-    target = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1)
-    predicted_score = haarpsi(prediction.to(device), target.to(device), data_range=255, reduction='none')
+    x = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1)
+    y = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1)
+    predicted_score = haarpsi(x.to(device), y.to(device), data_range=255, reduction='none')
     target_score = torch.tensor([0.71706527]).to(predicted_score)
     assert torch.isclose(predicted_score, target_score, atol=1e-4),\
         f'Expected result similar to MATLAB, got diff{predicted_score - target_score}'
@@ -78,18 +78,18 @@ def test_haarpsi_compare_with_matlab(device: str) -> None:
 
 # ================== Test class: `HaarPSILoss` =================
 def test_haarpsi_loss(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    prediction.requires_grad_()
-    loss = HaarPSILoss(data_range=1.)(prediction.to(device), target.to(device))
+    x, y = input_tensors
+    x.requires_grad_()
+    loss = HaarPSILoss(data_range=1.)(x.to(device), y.to(device))
     loss.backward()
-    assert torch.isfinite(prediction.grad).all(), \
-        f'Expected finite gradient values after back propagation, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), \
+        f'Expected finite gradient values after back propagation, got {x.grad}'
 
 
 def test_haarpsi_loss_zero_for_equal_input(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, _ = input_tensors
-    target = prediction.clone()
-    prediction.requires_grad_()
-    loss = HaarPSILoss(data_range=1.)(prediction.to(device), target.to(device))
+    x, _ = input_tensors
+    y = x.clone()
+    x.requires_grad_()
+    loss = HaarPSILoss(data_range=1.)(x.to(device), y.to(device))
     assert torch.isclose(loss, torch.zeros_like(loss), atol=1e-5), \
         f'Expected loss equals zero for identical inputs, got {loss}'

--- a/tests/test_kid.py
+++ b/tests/test_kid.py
@@ -5,23 +5,23 @@ from piq import KID
 
 
 @pytest.fixture(scope='module')
-def features_target_normal() -> torch.Tensor:
+def features_y_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_normal() -> torch.Tensor:
+def features_x_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_beta() -> torch.Tensor:
+def features_x_beta() -> torch.Tensor:
     m = torch.distributions.Beta(torch.FloatTensor([2]), torch.FloatTensor([2]))
     return m.sample([1000, 20]).squeeze()
 
 
 @pytest.fixture(scope='module')
-def features_prediction_constant() -> torch.Tensor:
+def features_x_constant() -> torch.Tensor:
     return torch.ones(1000, 20)
 
 
@@ -32,30 +32,30 @@ def test_initialization() -> None:
         pytest.fail(f"Unexpected error occurred: {e}")
 
 
-def test_forward(features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor, ) -> None:
+def test_forward(features_y_normal, features_x_normal, ) -> None:
     try:
         metric = KID()
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
     except Exception as e:
         pytest.fail(f"Unexpected error occurred: {e}")
 
 
-def tes_fails_for_different_dimensions(features_target_normal: torch.Tensor) -> None:
-    features_prediction_normal = torch.rand(1000, 21)
+def tes_fails_for_different_dimensions(features_y_normal: torch.Tensor) -> None:
+    features_x_normal = torch.rand(1000, 21)
     metric = KID()
     with pytest.raises(AssertionError):
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
 
 
-def test_works_for_different_number_of_images_in_stack(features_target_normal: torch.Tensor) -> None:
-    features_prediction_normal = torch.rand(1010, 20)
+def test_works_for_different_number_of_images_in_stack(features_y_normal) -> None:
+    features_x_normal = torch.rand(1010, 20)
     metric = KID()
-    metric(features_target_normal, features_prediction_normal)
+    metric(features_y_normal, features_x_normal)
 
 
-def test_returns_variance(features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor) -> None:
+def test_returns_variance(features_y_normal, features_x_normal) -> None:
     metric = KID(ret_var=True)
-    result = metric(features_target_normal, features_prediction_normal)
+    result = metric(features_y_normal, features_x_normal)
     print(result)
     assert len(result) == 2, \
         f'Expected to get score and variance, got {result}'

--- a/tests/test_mdsi.py
+++ b/tests/test_mdsi.py
@@ -4,46 +4,46 @@ from skimage.io import imread
 from piq import mdsi, MDSILoss
 from typing import Tuple, Any
 
-prediction_image = [
+x_image = [
     torch.tensor(imread('tests/assets/goldhill_jpeg.gif'), dtype=torch.float32).unsqueeze(0).unsqueeze(0),
     torch.tensor(imread('tests/assets/i01_01_5.bmp'), dtype=torch.float32).permute(2, 0, 1).unsqueeze(0)
 ]
 
-target_image = [
+y_image = [
     torch.tensor(imread('tests/assets/goldhill.gif'), dtype=torch.float32).unsqueeze(0).unsqueeze(0),
     torch.tensor(imread('tests/assets/I01.BMP'), dtype=torch.float32).permute(2, 0, 1).unsqueeze(0)
 ]
-target_score = [
+y_score = [
     {'sum': torch.tensor(0.395910876130775), 'mult': torch.tensor(0.328692181289061)},
     {'sum': torch.tensor(0.338972600511665), 'mult': torch.tensor(0.258002917257516)}
 ]
 
 
-@pytest.fixture(params=zip(prediction_image, target_image, target_score))
+@pytest.fixture(params=zip(x_image, y_image, y_score))
 def input_images_score(request: Any) -> Any:
     return request.param
 
 
 # ================== Test function: `mdsi` ==================
 def test_mdsi(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    score = mdsi(prediction=prediction.to(device), target=target.to(device), data_range=1., reduction='none')
+    x, y = input_tensors
+    score = mdsi(x=x.to(device), y=y.to(device), data_range=1., reduction='none')
     assert torch.isfinite(score).all(), f'Expected finite scores, got {score}'
 
 
 def test_mdsi_reduction(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
+    x, y = input_tensors
     for reduction in ['mean', 'sum', 'none']:
-        mdsi(prediction=prediction.to(device), target=target.to(device), data_range=1., reduction=reduction)
+        mdsi(x=x.to(device), y=y.to(device), data_range=1., reduction=reduction)
 
 
 def test_mdsi_combination(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
+    x, y = input_tensors
     for combination in ['sum', 'mult']:
-        mdsi(prediction=prediction.to(device), target=target.to(device), data_range=1., combination=combination)
+        mdsi(x=x.to(device), y=y.to(device), data_range=1., combination=combination)
     for combination in ['DEADBEEF', 'random']:
         with pytest.raises(ValueError):
-            mdsi(prediction=prediction.to(device), target=target.to(device), data_range=1., combination=combination)
+            mdsi(x=x.to(device), y=y.to(device), data_range=1., combination=combination)
 
 
 @pytest.mark.parametrize(
@@ -51,57 +51,56 @@ def test_mdsi_combination(input_tensors: Tuple[torch.Tensor, torch.Tensor], devi
 )
 def test_mdsi_supports_different_data_ranges(
         input_tensors: Tuple[torch.Tensor, torch.Tensor], data_range, device: str) -> None:
-    prediction, target = input_tensors
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+    x, y = input_tensors
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
 
-    measure_scaled = mdsi(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+    measure_scaled = mdsi(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = mdsi(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_mdsi_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_mdsi_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        mdsi(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        mdsi(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
         
 
 @pytest.mark.parametrize("combination", ['sum', 'mult'])
 def test_mdsi_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
                                   combination: str, device: str) -> None:
-    prediction, target, target_value = input_images_score
-    target_value = target_value[combination]
-    score = mdsi(prediction=prediction.to(device), target=target.to(device), data_range=255, combination=combination)
-    assert torch.isclose(score, target_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
-                                                         f'got {score.item():.8f}, while MATLAB equals {target_value}'
+    x, y, y_value = input_images_score
+    y_value = y_value[combination]
+    score = mdsi(x=x.to(device), y=y.to(device), data_range=255, combination=combination)
+    assert torch.isclose(score, y_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
+                                                         f'got {score.item():.8f}, while MATLAB equals {y_value}'
 
 
 # ================== Test function: `MDSILoss` ==================
 def test_mdsi_loss(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    prediction.requires_grad_()
-    loss = MDSILoss(data_range=1.)(prediction=prediction.to(device), target=target.to(device))
+    x, y = input_tensors
+    x.requires_grad_()
+    loss = MDSILoss(data_range=1.)(x=x.to(device), y=y.to(device))
     loss.backward()
-    assert torch.isfinite(prediction.grad).all(), f'Expected finite gradient values, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'
 
 
 @pytest.mark.parametrize("combination", ['sum', 'mult'])
 def test_mdsi_loss_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
                                        combination: str, device: str) -> None:
-    prediction, target, target_value = input_images_score
-    target_value = target_value[combination]
-    prediction = prediction.requires_grad_()
-    score = MDSILoss(data_range=255, combination=combination)(prediction=prediction.to(device),
-                                                              target=target.to(device))
+    x, y, y_value = input_images_score
+    y_value = y_value[combination]
+    x = x.requires_grad_()
+    score = MDSILoss(data_range=255, combination=combination)(x=x.to(device), y=y.to(device))
     score.backward()
-    assert torch.isclose(score, 1. - target_value.to(score)), f'The estimated value must be equal to MATLAB ' \
+    assert torch.isclose(score, 1. - y_value.to(score)), f'The estimated value must be equal to MATLAB ' \
                                                               f'provided one, got {score.item():.8f}, ' \
-                                                              f'while MATLAB equals {1. - target_value}'
-    assert torch.isfinite(prediction.grad).all(), f'Expected finite gradient values, got {prediction.grad}'
+                                                              f'while MATLAB equals {1. - y_value}'
+    assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'

--- a/tests/test_mdsi.py
+++ b/tests/test_mdsi.py
@@ -71,7 +71,7 @@ def test_mdsi_fails_for_incorrect_data_range(x, y, device: str) -> None:
     y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
         mdsi(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
-        
+
 
 @pytest.mark.parametrize("combination", ['sum', 'mult'])
 def test_mdsi_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
@@ -80,7 +80,7 @@ def test_mdsi_compare_with_matlab(input_images_score: Tuple[torch.Tensor, torch.
     y_value = y_value[combination]
     score = mdsi(x=x.to(device), y=y.to(device), data_range=255, combination=combination)
     assert torch.isclose(score, y_value.to(score)), f'The estimated value must be equal to MATLAB provided one, ' \
-                                                         f'got {score.item():.8f}, while MATLAB equals {y_value}'
+                                                    f'got {score.item():.8f}, while MATLAB equals {y_value}'
 
 
 # ================== Test function: `MDSILoss` ==================
@@ -101,6 +101,6 @@ def test_mdsi_loss_compare_with_matlab(input_images_score: Tuple[torch.Tensor, t
     score = MDSILoss(data_range=255, combination=combination)(x=x.to(device), y=y.to(device))
     score.backward()
     assert torch.isclose(score, 1. - y_value.to(score)), f'The estimated value must be equal to MATLAB ' \
-                                                              f'provided one, got {score.item():.8f}, ' \
-                                                              f'while MATLAB equals {1. - y_value}'
+                                                         f'provided one, got {score.item():.8f}, ' \
+                                                         f'while MATLAB equals {1. - y_value}'
     assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'

--- a/tests/test_msid.py
+++ b/tests/test_msid.py
@@ -21,49 +21,49 @@ class TestDataset(torch.utils.data.Dataset):
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(3, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(3, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def features_target_normal() -> torch.Tensor:
+def features_y_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_normal() -> torch.Tensor:
+def features_x_normal() -> torch.Tensor:
     return torch.rand(1000, 20)
 
 
 @pytest.fixture(scope='module')
-def features_prediction_beta() -> torch.Tensor:
+def features_x_beta() -> torch.Tensor:
     m = torch.distributions.Beta(torch.FloatTensor([2]), torch.FloatTensor([2]))
     return m.sample([1000, 20]).squeeze()
 
 
 @pytest.fixture(scope='module')
-def features_prediction_constant() -> torch.Tensor:
+def features_x_constant() -> torch.Tensor:
     return torch.ones(1000, 20)
 
 
 # ================== Test class: `MSID` ==================
-def test_fails_for_different_dimensions(features_target_normal: torch.Tensor) -> None:
-    features_prediction_normal = torch.rand(1000, 21)
+def test_fails_for_different_dimensions(features_y_normal) -> None:
+    features_x_normal = torch.rand(1000, 21)
     metric = MSID()
     with pytest.raises(AssertionError):
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
 
 
-def test_compute_msid_works_for_different_number_of_images_in_stack(features_target_normal: torch.Tensor) -> None:
-    features_prediction_normal = torch.rand(1001, 20)
+def test_compute_msid_works_for_different_number_of_images_in_stack(features_y_normal) -> None:
+    features_x_normal = torch.rand(1001, 20)
     metric = MSID()
     try:
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
     except Exception as e:
         pytest.fail(f"Unexpected error occurred: {e}")
 
@@ -76,22 +76,18 @@ def test_initialization() -> None:
 
 
 @pytest.mark.skip(reason="Sometimes it doesn't work.")
-def test_msid_is_smaller_for_equal_tensors(
-        features_target_normal: torch.Tensor,
-        features_prediction_normal: torch.Tensor,
-        features_prediction_constant: torch.Tensor
-) -> None:
+def test_msid_is_smaller_for_equal_tensors(features_y_normal, features_x_normal, features_x_constant) -> None:
     metric = MSID()
-    measure = metric(features_target_normal, features_prediction_normal)
-    measure_constant = metric(features_target_normal, features_prediction_normal)
+    measure = metric(features_y_normal, features_x_normal)
+    measure_constant = metric(features_y_normal, features_x_normal)
     assert measure <= measure_constant, \
         f'MSID should be smaller for samples from the same distribution, got {measure} and {measure_constant}'
 
 
-def test_forward(features_target_normal: torch.Tensor, features_prediction_normal: torch.Tensor, ) -> None:
+def test_forward(features_y_normal, features_x_normal, ) -> None:
     try:
         metric = MSID()
-        metric(features_target_normal, features_prediction_normal)
+        metric(features_y_normal, features_x_normal)
     except Exception as e:
         pytest.fail(f"Unexpected error occurred: {e}")
 

--- a/tests/test_perseptual.py
+++ b/tests/test_perseptual.py
@@ -22,26 +22,26 @@ def test_content_loss_init() -> None:
 
 
 def test_content_loss_forward(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
+    x, y = input_tensors
     loss = ContentLoss()
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
 def test_content_loss_computes_grad(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    prediction.requires_grad_()
-    loss_value = ContentLoss()(prediction.to(device), target.to(device))
+    x, y = input_tensors
+    x.requires_grad_()
+    loss_value = ContentLoss()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG
 
 
-def test_content_loss_raises_if_wrong_reduction(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_content_loss_raises_if_wrong_reduction(x, y) -> None:
     for mode in ['mean', 'sum', 'none']:
-        ContentLoss(reduction=mode)(prediction, target)
+        ContentLoss(reduction=mode)(x, y)
 
     for mode in [None, 'n', 2]:
         with pytest.raises(KeyError):
-            ContentLoss(reduction=mode)(prediction, target)
+            ContentLoss(reduction=mode)(x, y)
 
 
 @pytest.mark.parametrize(
@@ -54,8 +54,7 @@ def test_content_loss_raises_if_wrong_reduction(prediction: torch.Tensor, target
         ('random_encoder', pytest.raises(ValueError)),
     ],
 )
-def test_content_loss_raises_if_wrong_extractor(
-        prediction: torch.Tensor, target: torch.Tensor, model: Union[str, Callable], expectation: Any) -> None:
+def test_content_loss_raises_if_wrong_extractor(x, y, model: Union[str, Callable], expectation: Any) -> None:
     with expectation:
         ContentLoss(feature_extractor=model)
 
@@ -63,18 +62,17 @@ def test_content_loss_raises_if_wrong_extractor(
 @pytest.mark.parametrize(
     "model", ['vgg16', InceptionV3()],
 )
-def test_content_loss_replace_pooling(
-        prediction: torch.Tensor, target: torch.Tensor, model: Union[str, Callable]) -> None:
+def test_content_loss_replace_pooling(x, y, model: Union[str, Callable]) -> None:
     ContentLoss(feature_extractor=model, replace_pooling=True)
 
 
-def test_content_loss_supports_custom_extractor(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_content_loss_supports_custom_extractor(x, y, device: str) -> None:
     loss = ContentLoss(feature_extractor=InceptionV3().blocks, layers=['0', '1'])
-    loss(prediction, target)
+    loss(x, y)
 
 
 @pytest.mark.parametrize(
-    "prediction,target,expectation,value",
+    "x, y, expectation, value",
     [
         (torch.rand(2, 3, 96, 96, 2), torch.rand(2, 3, 96, 96, 2), pytest.raises(AssertionError), None),
         (torch.randn(2, 3, 96, 96), torch.randn(2, 3, 96, 96), raise_nothing(), None),
@@ -83,24 +81,23 @@ def test_content_loss_supports_custom_extractor(prediction: torch.Tensor, target
         (torch.rand(2, 3, 28, 28), torch.rand(2, 3, 28, 28), pytest.raises(RuntimeError), None),
     ],
 )
-def test_content_loss_forward_for_special_cases(
-        prediction: torch.Tensor, target: torch.Tensor, expectation: Any, value: float) -> None:
+def test_content_loss_forward_for_special_cases(x, y, expectation: Any, value: float) -> None:
     loss = ContentLoss()
     with expectation:
         if value is None:
-            loss(prediction, target)
+            loss(x, y)
         else:
-            loss_value = loss(prediction, target)
+            loss_value = loss(x, y)
             assert torch.isclose(loss_value, torch.tensor(value)), \
                 f'Expected loss value to be equal to target value. Got {loss_value} and {value}'
 
 
 @pytest.mark.skip("Negative tensors are not supported yet")
 def test_content_loss_forward_for_normalized_input(device: str) -> None:
-    prediction = torch.randn(2, 3, 96, 96).to(device)
-    target = torch.randn(2, 3, 96, 96).to(device)
+    x = torch.randn(2, 3, 96, 96).to(device)
+    y = torch.randn(2, 3, 96, 96).to(device)
     loss = ContentLoss(mean=[0., 0., 0.], std=[1., 1., 1.])
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
 # ================== Test class: `StyleLoss` ==================
@@ -109,26 +106,26 @@ def test_style_loss_init() -> None:
 
 
 def test_style_loss_forward(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
+    x, y = input_tensors
     loss = StyleLoss()
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
 def test_style_loss_computes_grad(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    prediction.requires_grad_()
-    loss_value = StyleLoss()(prediction.to(device), target.to(device))
+    x, y = input_tensors
+    x.requires_grad_()
+    loss_value = StyleLoss()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG
 
 
-def test_style_loss_raises_if_wrong_reduction(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_style_loss_raises_if_wrong_reduction(x, y) -> None:
     for mode in ['mean', 'sum', 'none']:
-        StyleLoss(reduction=mode)(prediction, target)
+        StyleLoss(reduction=mode)(x, y)
 
     for mode in [None, 'n', 2]:
         with pytest.raises(KeyError):
-            StyleLoss(reduction=mode)(prediction, target)
+            StyleLoss(reduction=mode)(x, y)
 
 
 # ================== Test class: `LPIPS` ==================
@@ -137,68 +134,66 @@ def test_lpips_loss_init() -> None:
 
 
 def test_lpips_loss_forward(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
+    x, y = input_tensors
     loss = LPIPS()
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
-def test_lpips_computes_grad(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = LPIPS()(prediction.to(device), target.to(device))
+def test_lpips_computes_grad(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = LPIPS()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG
 
 
-def test_lpips_loss_raises_if_wrong_reduction(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_lpips_loss_raises_if_wrong_reduction(x, y) -> None:
     for mode in ['mean', 'sum', 'none']:
-        LPIPS(reduction=mode)(prediction, target)
+        LPIPS(reduction=mode)(x, y)
 
     for mode in [None, 'n', 2]:
         with pytest.raises(KeyError):
-            LPIPS(reduction=mode)(prediction, target)
+            LPIPS(reduction=mode)(x, y)
 
 
 @pytest.mark.parametrize(
-    "prediction,target,expectation,value",
+    "x, y, expectation, value",
     [
         (torch.zeros(2, 3, 96, 96), torch.zeros(2, 3, 96, 96), raise_nothing(), 0.0),
         (torch.ones(2, 3, 96, 96), torch.ones(2, 3, 96, 96), raise_nothing(), 0.0),
     ],
 )
-def test_lpips_loss_forward_for_special_cases(
-        prediction: torch.Tensor, target: torch.Tensor, expectation: Any, value: float) -> None:
+def test_lpips_loss_forward_for_special_cases(x, y, expectation: Any, value: float) -> None:
     loss = LPIPS()
     with expectation:
-        loss_value = loss(prediction, target)
+        loss_value = loss(x, y)
         assert torch.isclose(loss_value, torch.tensor(value), atol=1e-6), \
             f'Expected loss value to be equal to target value. Got {loss_value} and {value}'
 
 
 # ================== Test class: `DISTS` ==================
-def test_dists_loss_forward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_dists_loss_forward(x, y, device: str) -> None:
     loss = DISTS()
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
 
-def test_dists_computes_grad(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = DISTS()(prediction.to(device), target.to(device))
+def test_dists_computes_grad(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = DISTS()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG
 
 
 @pytest.mark.parametrize(
-    "prediction,target,expectation,value",
+    "x, y, expectation, value",
     [
         (torch.zeros(2, 3, 96, 96), torch.zeros(2, 3, 96, 96), raise_nothing(), 0.0),
         (torch.ones(2, 3, 96, 96), torch.ones(2, 3, 96, 96), raise_nothing(), 0.0),
     ],
 )
-def test_dists_loss_forward_for_special_cases(
-        prediction: torch.Tensor, target: torch.Tensor, expectation: Any, value: float) -> None:
+def test_dists_loss_forward_for_special_cases(x, y, expectation: Any, value: float) -> None:
     loss = DISTS()
     with expectation:
-        loss_value = loss(prediction, target)
+        loss_value = loss(x, y)
         assert torch.isclose(loss_value, torch.tensor(value), atol=1e-6), \
             f'Expected loss value to be equal to target value. Got {loss_value} and {value}'
 

--- a/tests/test_psnr.py
+++ b/tests/test_psnr.py
@@ -7,19 +7,19 @@ from piq import psnr
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(4, 3, 128, 128)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(4, 3, 128, 128)
 
 
 # ================== Test function: `psnr` ==================
 def test_psnr(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    psnr(prediction.to(device), target.to(device), data_range=1.0)
+    x, y = input_tensors
+    psnr(x.to(device), y.to(device), data_range=1.0)
 
 
 @pytest.mark.parametrize(
@@ -27,82 +27,82 @@ def test_psnr(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> 
 )
 def test_psnr_supports_different_data_ranges(
         input_tensors: Tuple[torch.Tensor, torch.Tensor], data_range, device: str) -> None:
-    prediction, target = input_tensors
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+    x, y = input_tensors
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
 
-    measure_scaled = psnr(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+    measure_scaled = psnr(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = psnr(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_psnr_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_psnr_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        psnr(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        psnr(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
         
         
 def test_psnr_works_for_zero_tensors() -> None:
-    prediction = torch.zeros(4, 3, 256, 256)
-    target = torch.zeros(4, 3, 256, 256)
-    measure = psnr(prediction, target, data_range=1.0)
+    x = torch.zeros(4, 3, 256, 256)
+    y = torch.zeros(4, 3, 256, 256)
+    measure = psnr(x, y, data_range=1.0)
     assert torch.isclose(measure, torch.tensor(80.))
 
 
-def test_psnr_big_for_identical_images(prediction: torch.Tensor) -> None:
+def test_psnr_big_for_identical_images(x) -> None:
     # Max value depends on EPS constant. It's 80 for EPS=1e-8, 100 for EPS=1e-10 etc.
     max_val = torch.tensor(80.)
 
-    target = prediction.clone()
-    measure = psnr(prediction, target, data_range=1.0)
+    y = x.clone()
+    measure = psnr(x, y, data_range=1.0)
     assert torch.isclose(measure, max_val), f"PSNR for identical images should be 80, got {measure}"
 
 
-def test_psnr_reduction(prediction: torch.Tensor, target: torch.Tensor):
-    measure = psnr(prediction, target, reduction='mean')
+def test_psnr_reduction(x, y):
+    measure = psnr(x, y, reduction='mean')
     assert measure.dim() == 0, f'PSNR with `mean` reduction must return 1 number, got {len(measure)}'
 
-    measure = psnr(prediction, target, reduction='sum')
+    measure = psnr(x, y, reduction='sum')
     assert measure.dim() == 0, f'PSNR with `mean` reduction must return 1 number, got {len(measure)}'
 
-    measure = psnr(prediction, target, reduction='none')
-    assert len(measure) == prediction.size(0), \
+    measure = psnr(x, y, reduction='none')
+    assert len(measure) == x.size(0), \
         f'PSNR with `none` reduction must have length equal to number of images, got {len(measure)}'
 
     with pytest.raises(KeyError):
-        psnr(prediction, target, reduction='random string')
+        psnr(x, y, reduction='random string')
 
 
 def test_psnr_matches_skimage_greyscale():
-    prediction = torch.rand(1, 1, 256, 256)
-    target = torch.rand(1, 1, 256, 256)
-    pm_measure = psnr(prediction, target, reduction='mean')
-    sk_measure = peak_signal_noise_ratio(prediction.squeeze().numpy(), target.squeeze().numpy(), data_range=1.0)
+    x = torch.rand(1, 1, 256, 256)
+    y = torch.rand(1, 1, 256, 256)
+    pm_measure = psnr(x, y, reduction='mean')
+    sk_measure = peak_signal_noise_ratio(x.squeeze().numpy(), y.squeeze().numpy(), data_range=1.0)
 
     assert torch.isclose(pm_measure, torch.tensor(sk_measure, dtype=pm_measure.dtype)), \
         f"Must match Sklearn version. Got: {pm_measure} and skimage: {sk_measure}"
 
 
 def test_psnr_matches_skimage_rgb():
-    prediction = torch.rand(1, 3, 256, 256)
-    target = torch.rand(1, 3, 256, 256)
-    pm_measure = psnr(prediction, target, reduction='mean')
-    sk_measure = peak_signal_noise_ratio(prediction.squeeze().numpy(), target.squeeze().numpy(), data_range=1.0)
+    x = torch.rand(1, 3, 256, 256)
+    y = torch.rand(1, 3, 256, 256)
+    pm_measure = psnr(x, y, reduction='mean')
+    sk_measure = peak_signal_noise_ratio(x.squeeze().numpy(), y.squeeze().numpy(), data_range=1.0)
 
     assert torch.isclose(pm_measure, torch.tensor(sk_measure, dtype=pm_measure.dtype)), \
         f"Must match Sklearn version. Got: {pm_measure} and skimage: {sk_measure}"
 
 
 def test_psnr_loss_backward():
-    prediction = torch.rand(1, 3, 256, 256, requires_grad=True)
-    target = torch.rand(1, 3, 256, 256)
-    loss = 80 - psnr(prediction, target, reduction='mean')
+    x = torch.rand(1, 3, 256, 256, requires_grad=True)
+    y = torch.rand(1, 3, 256, 256)
+    loss = 80 - psnr(x, y, reduction='mean')
     loss.backward()
-    assert prediction.grad is not None, 'Expected non None gradient of leaf variable'
+    assert x.grad is not None, 'Expected non None gradient of leaf variable'

--- a/tests/test_ssim.py
+++ b/tests/test_ssim.py
@@ -14,17 +14,17 @@ def raise_nothing(enter_result=None):
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(3, 3, 161, 161)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(3, 3, 161, 161)
 
 
 @pytest.fixture(params=[(3, 3, 161, 161), (3, 3, 161, 161, 2)], scope='module')
-def prediction_target_4d_5d(request: Any) -> Tuple[torch.Tensor, torch.Tensor]:
+def x_y_4d_5d(request: Any) -> Tuple[torch.Tensor, torch.Tensor]:
     return torch.rand(request.param), torch.rand(request.param)
 
 
@@ -35,11 +35,11 @@ def ones_zeros_4d_5d(request: Any) -> Tuple[torch.Tensor, torch.Tensor]:
 
 @pytest.fixture(scope='module')
 def test_images() -> List[Tuple[torch.Tensor, torch.Tensor]]:
-    prediction_grey = torch.tensor(imread('tests/assets/goldhill_jpeg.gif')).unsqueeze(0).unsqueeze(0)
-    target_grey = torch.tensor(imread('tests/assets/goldhill.gif')).unsqueeze(0).unsqueeze(0)
-    prediction_rgb = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1).unsqueeze(0)
-    target_rgb = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1).unsqueeze(0)
-    return [(prediction_grey, target_grey), (prediction_rgb, target_rgb)]
+    x_grey = torch.tensor(imread('tests/assets/goldhill_jpeg.gif')).unsqueeze(0).unsqueeze(0)
+    y_grey = torch.tensor(imread('tests/assets/goldhill.gif')).unsqueeze(0).unsqueeze(0)
+    x_rgb = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1).unsqueeze(0)
+    y_rgb = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1).unsqueeze(0)
+    return [(x_grey, y_grey), (x_rgb, y_rgb)]
 
 
 @pytest.fixture(params=[[0.0448, 0.2856, 0.3001, 0.2363, 0.1333], [0.0448, 0.2856, 0.3001]], scope='module')
@@ -48,37 +48,37 @@ def scale_weights(request: Any) -> List:
 
 
 # ================== Test function: `ssim` ==================
-def test_ssim_symmetry(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
-    measure = ssim(prediction, target, data_range=1., reduction='none')
-    reverse_measure = ssim(target, prediction, data_range=1., reduction='none')
+def test_ssim_symmetry(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
+    measure = ssim(x, y, data_range=1., reduction='none')
+    reverse_measure = ssim(y, x, data_range=1., reduction='none')
     assert torch.allclose(measure, reverse_measure), f'Expect: SSIM(a, b) == SSIM(b, a), ' \
                                                      f'got {measure} != {reverse_measure}'
 
 
-def test_ssim_measure_is_one_for_equal_tensors(target: torch.Tensor, device: str) -> None:
-    target = target.to(device)
-    prediction = target.clone()
-    measure = ssim(prediction, target, data_range=1., reduction='none')
+def test_ssim_measure_is_one_for_equal_tensors(y: torch.Tensor, device: str) -> None:
+    y = y.to(device)
+    x = y.clone()
+    measure = ssim(x, y, data_range=1., reduction='none')
     assert torch.allclose(measure, torch.ones_like(measure)), f'If equal tensors are passed SSIM must be equal to 1 ' \
                                                               f'(considering floating point error up to 1 * 10^-6), '\
                                                               f'got {measure}'
 
 
-def test_ssim_reduction(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_ssim_reduction(x: torch.Tensor, y: torch.Tensor, device: str) -> None:
     for mode in ['mean', 'sum', 'none']:
-        ssim(prediction.to(device), target.to(device), reduction=mode)
+        ssim(x.to(device), y.to(device), reduction=mode)
 
     for mode in [None, 'n', 2]:
         with pytest.raises(KeyError):
-            ssim(prediction.to(device), target.to(device), reduction=mode)
+            ssim(x.to(device), y.to(device), reduction=mode)
             
 
-def test_ssim_returns_full(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction = prediction.to(device)
-    target = target.to(device)
-    assert len(ssim(prediction, target, full=True)) == 2, "Expected 2 output values, got 1"
+def test_ssim_returns_full(x: torch.Tensor, y: torch.Tensor, device: str) -> None:
+    x = x.to(device)
+    y = y.to(device)
+    assert len(ssim(x, y, full=True)) == 2, "Expected 2 output values, got 1"
         
 
 def test_ssim_measure_is_less_or_equal_to_one(ones_zeros_4d_5d: Tuple[torch.Tensor, torch.Tensor],
@@ -90,79 +90,77 @@ def test_ssim_measure_is_less_or_equal_to_one(ones_zeros_4d_5d: Tuple[torch.Tens
     assert torch.le(measure, 1).all(), f'SSIM must be <= 1, got {measure}'
 
 
-def test_ssim_raises_if_tensors_have_different_shapes(prediction_target_4d_5d: Tuple[torch.Tensor,
-                                                                                     torch.Tensor], device) -> None:
-    target = prediction_target_4d_5d[1].to(device)
+def test_ssim_raises_if_tensors_have_different_shapes(x_y_4d_5d, device) -> None:
+    y = x_y_4d_5d[1].to(device)
     dims = [[3], [2, 3], [161, 162], [161, 162]]
-    if target.dim() == 5:
+    if y.dim() == 5:
         dims += [[2, 3]]
     for size in list(itertools.product(*dims)):
-        wrong_shape_prediction = torch.rand(size).to(target)
-        if wrong_shape_prediction.size() == target.size():
+        wrong_shape_x = torch.rand(size).to(y)
+        if wrong_shape_x.size() == y.size():
             try:
-                ssim(wrong_shape_prediction, target)
+                ssim(wrong_shape_x, y)
             except Exception as e:
                 pytest.fail(f"Unexpected error occurred: {e}")
         else:
             with pytest.raises(AssertionError):
-                ssim(wrong_shape_prediction, target)
+                ssim(wrong_shape_x, y)
 
 
-def test_ssim_raises_if_tensors_have_different_types(target: torch.Tensor) -> None:
-    wrong_type_prediction = list(range(10))
+def test_ssim_raises_if_tensors_have_different_types(y: torch.Tensor) -> None:
+    wrong_type_x = list(range(10))
     with pytest.raises(AssertionError):
-        ssim(wrong_type_prediction, target)
+        ssim(wrong_type_x, y)
 
 
 def test_ssim_check_available_dimensions() -> None:
-    custom_prediction = torch.rand(256, 256)
-    custom_target = torch.rand(256, 256)
+    custom_x = torch.rand(256, 256)
+    custom_y = torch.rand(256, 256)
     for _ in range(10):
-        if custom_prediction.dim() < 5:
+        if custom_x.dim() < 5:
             try:
-                ssim(custom_prediction, custom_target)
+                ssim(custom_x, custom_y)
             except Exception as e:
                 pytest.fail(f"Unexpected error occurred: {e}")
         else:
             with pytest.raises(AssertionError):
-                ssim(custom_prediction, custom_target)
-        custom_prediction.unsqueeze_(0)
-        custom_target.unsqueeze_(0)
+                ssim(custom_x, custom_y)
+        custom_x.unsqueeze_(0)
+        custom_y.unsqueeze_(0)
 
 
-def test_ssim_check_kernel_size_is_passed(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor],
-                                          device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ssim_check_kernel_size_is_passed(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     kernel_sizes = list(range(0, 50))
     for kernel_size in kernel_sizes:
         if kernel_size % 2:
-            ssim(prediction, target, kernel_size=kernel_size)
+            ssim(x, y, kernel_size=kernel_size)
         else:
             with pytest.raises(AssertionError):
-                ssim(prediction, target, kernel_size=kernel_size)
+                ssim(x, y, kernel_size=kernel_size)
 
 
-def test_ssim_raises_if_kernel_size_greater_than_image(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor],
-                                                       device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ssim_raises_if_kernel_size_greater_than_image(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     kernel_size = 11
-    wrong_size_prediction = prediction[:, :, :kernel_size - 1, :kernel_size - 1]
-    wrong_size_target = target[:, :, :kernel_size - 1, :kernel_size - 1]
+    wrong_size_x = x[:, :, :kernel_size - 1, :kernel_size - 1]
+    wrong_size_y = y[:, :, :kernel_size - 1, :kernel_size - 1]
     with pytest.raises(ValueError):
-        ssim(wrong_size_prediction, wrong_size_target, kernel_size=kernel_size)
+        ssim(wrong_size_x, wrong_size_y, kernel_size=kernel_size)
 
 
 def test_ssim_raise_if_wrong_value_is_estimated(test_images: Tuple[torch.Tensor, torch.Tensor],
                                                 device: str) -> None:
-    for prediction, target in test_images:
-        piq_ssim = ssim(prediction.to(device), target.to(device), kernel_size=11, kernel_sigma=1.5, data_range=255,
+    for x, y in test_images:
+        piq_ssim = ssim(x.to(device), y.to(device), kernel_size=11, kernel_sigma=1.5, data_range=255,
                         reduction='none')
-        tf_prediction = tf.convert_to_tensor(prediction.permute(0, 2, 3, 1).numpy())
-        tf_target = tf.convert_to_tensor(target.permute(0, 2, 3, 1).numpy())
+        tf_x = tf.convert_to_tensor(x.permute(0, 2, 3, 1).numpy())
+        tf_y = tf.convert_to_tensor(y.permute(0, 2, 3, 1).numpy())
         with tf.device('/CPU'):
-            tf_ssim = torch.tensor(tf.image.ssim(tf_prediction, tf_target, max_val=255).numpy()).to(piq_ssim)
+            tf_ssim = torch.tensor(tf.image.ssim(tf_x, tf_y, max_val=255).numpy()).to(piq_ssim)
+
         match_accuracy = 2e-4 + 1e-8
         assert torch.allclose(piq_ssim, tf_ssim, rtol=0, atol=match_accuracy), \
             f'The estimated value must be equal to tensorflow provided one' \
@@ -175,52 +173,52 @@ def test_ssim_raise_if_wrong_value_is_estimated(test_images: Tuple[torch.Tensor,
 )
 def test_ssim_supports_different_data_ranges(
         input_tensors: Tuple[torch.Tensor, torch.Tensor], data_range, device: str) -> None:
-    prediction, target = input_tensors
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+    x, y = input_tensors
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
 
-    measure_scaled = ssim(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+    measure_scaled = ssim(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = ssim(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-6, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_ssim_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_ssim_fails_for_incorrect_data_range(x: torch.Tensor, y: torch.Tensor, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        ssim(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        ssim(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
 
 
 # ================== Test class: `SSIMLoss` ==================
-def test_ssim_loss_grad(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
-    prediction.requires_grad_(True)
-    loss = SSIMLoss(data_range=1.)(prediction, target).mean()
+def test_ssim_loss_grad(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
+    x.requires_grad_(True)
+    loss = SSIMLoss(data_range=1.)(x, y).mean()
     loss.backward()
-    assert torch.isfinite(prediction.grad).all(), f'Expected finite gradient values, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'
 
 
-def test_ssim_loss_symmetry(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ssim_loss_symmetry(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     loss = SSIMLoss()
-    loss_value = loss(prediction, target)
-    reverse_loss_value = loss(target, prediction)
+    loss_value = loss(x, y)
+    reverse_loss_value = loss(y, x)
     assert torch.allclose(loss_value, reverse_loss_value), \
         f'Expect: SSIMLoss(a, b) == SSIMLoss(b, a), got {loss_value} != {reverse_loss_value}'
 
 
-def test_ssim_loss_equality(target: torch.Tensor, device: str) -> None:
-    target = target.to(device)
-    prediction = target.clone()
-    loss = SSIMLoss()(prediction, target)
+def test_ssim_loss_equality(y: torch.Tensor, device: str) -> None:
+    y = y.to(device)
+    x = y.clone()
+    loss = SSIMLoss()(x, y)
     assert torch.allclose(loss, torch.zeros_like(loss)), \
         f'If equal tensors are passed SSIM loss must be equal to 0 '\
         f'(considering floating point operation error up to 1 * 10^-6), got {loss}'
@@ -234,74 +232,72 @@ def test_ssim_loss_is_less_or_equal_to_one(ones_zeros_4d_5d: Tuple[torch.Tensor,
     assert (loss <= 1).all(), f'SSIM loss must be <= 1, got {loss}'
 
 
-def test_ssim_loss_raises_if_tensors_have_different_shapes(prediction_target_4d_5d: Tuple[torch.Tensor,
-                                                                                          torch.Tensor],
+def test_ssim_loss_raises_if_tensors_have_different_shapes(x_y_4d_5d,
                                                            device) -> None:
-    target = prediction_target_4d_5d[1].to(device)
+    y = x_y_4d_5d[1].to(device)
     dims = [[3], [2, 3], [161, 162], [161, 162]]
-    if target.dim() == 5:
+    if y.dim() == 5:
         dims += [[2, 3]]
     for size in list(itertools.product(*dims)):
-        wrong_shape_prediction = torch.rand(size).to(target)
-        if wrong_shape_prediction.size() == target.size():
-            SSIMLoss()(wrong_shape_prediction, target)
+        wrong_shape_x = torch.rand(size).to(y)
+        if wrong_shape_x.size() == y.size():
+            SSIMLoss()(wrong_shape_x, y)
         else:
             with pytest.raises(AssertionError):
-                SSIMLoss()(wrong_shape_prediction, target)
+                SSIMLoss()(wrong_shape_x, y)
 
 
 def test_ssim_loss_check_available_dimensions() -> None:
-    custom_prediction = torch.rand(256, 256)
-    custom_target = torch.rand(256, 256)
+    custom_x = torch.rand(256, 256)
+    custom_y = torch.rand(256, 256)
     for _ in range(10):
-        if custom_prediction.dim() < 5:
+        if custom_x.dim() < 5:
             try:
-                SSIMLoss()(custom_prediction, custom_target)
+                SSIMLoss()(custom_x, custom_y)
             except Exception as e:
                 pytest.fail(f"Unexpected error occurred: {e}")
         else:
             with pytest.raises(AssertionError):
-                SSIMLoss()(custom_prediction, custom_target)
-        custom_prediction.unsqueeze_(0)
-        custom_target.unsqueeze_(0)
+                SSIMLoss()(custom_x, custom_y)
+        custom_x.unsqueeze_(0)
+        custom_y.unsqueeze_(0)
 
 
-def test_ssim_loss_raises_if_tensors_have_different_types(target: torch.Tensor) -> None:
-    wrong_type_prediction = list(range(10))
+def test_ssim_loss_raises_if_tensors_have_different_types(y: torch.Tensor) -> None:
+    wrong_type_x = list(range(10))
     with pytest.raises(AssertionError):
-        SSIMLoss()(wrong_type_prediction, target)
+        SSIMLoss()(wrong_type_x, y)
 
 
-def test_ssim_loss_check_kernel_size_is_passed(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_ssim_loss_check_kernel_size_is_passed(x: torch.Tensor, y: torch.Tensor) -> None:
     kernel_sizes = list(range(0, 50))
     for kernel_size in kernel_sizes:
         if kernel_size % 2:
-            SSIMLoss(kernel_size=kernel_size)(prediction, target)
+            SSIMLoss(kernel_size=kernel_size)(x, y)
         else:
             with pytest.raises(AssertionError):
-                SSIMLoss(kernel_size=kernel_size)(prediction, target)
+                SSIMLoss(kernel_size=kernel_size)(x, y)
 
 
-def test_ssim_loss_raises_if_kernel_size_greater_than_image(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor],
-                                                            device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ssim_loss_raises_if_kernel_size_greater_than_image(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     kernel_size = 11
-    wrong_size_prediction = prediction[:, :, :kernel_size - 1, :kernel_size - 1]
-    wrong_size_target = target[:, :, :kernel_size - 1, :kernel_size - 1]
+    wrong_size_x = x[:, :, :kernel_size - 1, :kernel_size - 1]
+    wrong_size_y = y[:, :, :kernel_size - 1, :kernel_size - 1]
     with pytest.raises(ValueError):
-        SSIMLoss(kernel_size=kernel_size)(wrong_size_prediction, wrong_size_target)
+        SSIMLoss(kernel_size=kernel_size)(wrong_size_x, wrong_size_y)
 
 
 def test_ssim_loss_raise_if_wrong_value_is_estimated(test_images: Tuple[torch.Tensor, torch.Tensor],
                                                      device: str) -> None:
-    for prediction, target in test_images:
-        ssim_loss = SSIMLoss(kernel_size=11, kernel_sigma=1.5, data_range=255, reduction='mean')(prediction.to(device),
-                                                                                                 target.to(device))
-        tf_prediction = tf.convert_to_tensor(prediction.permute(0, 2, 3, 1).numpy())
-        tf_target = tf.convert_to_tensor(target.permute(0, 2, 3, 1).numpy())
+    for x, y in test_images:
+        ssim_loss = SSIMLoss(kernel_size=11, kernel_sigma=1.5, data_range=255, reduction='mean')(x.to(device),
+                                                                                                 y.to(device))
+        tf_x = tf.convert_to_tensor(x.permute(0, 2, 3, 1).numpy())
+        tf_y = tf.convert_to_tensor(y.permute(0, 2, 3, 1).numpy())
         with tf.device('/CPU'):
-            tf_ssim = torch.tensor(tf.image.ssim(tf_prediction, tf_target, max_val=255).numpy()).mean().to(device)
+            tf_ssim = torch.tensor(tf.image.ssim(tf_x, tf_y, max_val=255).numpy()).mean().to(device)
         match_accuracy = 2e-4 + 1e-8
         assert torch.isclose(ssim_loss, 1. - tf_ssim, rtol=0, atol=match_accuracy), \
             f'The estimated value must be equal to tensorflow provided one' \
@@ -310,19 +306,19 @@ def test_ssim_loss_raise_if_wrong_value_is_estimated(test_images: Tuple[torch.Te
 
 
 # ================== Test function: `multi_scale_ssim` ==================
-def test_multi_scale_ssim_symmetry(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
-    measure = multi_scale_ssim(prediction, target, data_range=1., reduction='none')
-    reverse_measure = multi_scale_ssim(target, prediction, data_range=1., reduction='none')
+def test_multi_scale_ssim_symmetry(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
+    measure = multi_scale_ssim(x, y, data_range=1., reduction='none')
+    reverse_measure = multi_scale_ssim(y, x, data_range=1., reduction='none')
     assert torch.allclose(measure, reverse_measure), f'Expect: MS-SSIM(a, b) == MSSSIM(b, a), '\
                                                      f'got {measure} != {reverse_measure}'
 
 
-def test_multi_scale_ssim_measure_is_one_for_equal_tensors(target: torch.Tensor, device: str) -> None:
-    target = target.to(device)
-    prediction = target.clone()
-    measure = multi_scale_ssim(prediction, target, data_range=1.)
+def test_multi_scale_ssim_measure_is_one_for_equal_tensors(x: torch.Tensor, device: str) -> None:
+    x = x.to(device)
+    y = x.clone()
+    measure = multi_scale_ssim(y, x, data_range=1.)
     assert torch.allclose(measure, torch.ones_like(measure)), \
         f'If equal tensors are passed MS-SSIM must be equal to 1 ' \
         f'(considering floating point operation error up to 1 * 10^-6), got {measure + 1}'
@@ -337,83 +333,80 @@ def test_multi_scale_ssim_measure_is_less_or_equal_to_one(ones_zeros_4d_5d: Tupl
     assert (measure <= 1).all(), f'MS-SSIM must be <= 1, got {measure}'
 
 
-def test_multi_scale_ssim_raises_if_tensors_have_different_shapes(prediction_target_4d_5d: Tuple[torch.Tensor,
-                                                                                                 torch.Tensor],
-                                                                  device: str) -> None:
-    target = prediction_target_4d_5d[1].to(device)
+def test_multi_scale_ssim_raises_if_tensors_have_different_shapes(x_y_4d_5d, device: str) -> None:
+    y = x_y_4d_5d[1].to(device)
     dims = [[3], [2, 3], [161, 162], [161, 162]]
-    if target.dim() == 5:
+    if y.dim() == 5:
         dims += [[2, 3]]
     for size in list(itertools.product(*dims)):
-        wrong_shape_prediction = torch.rand(size).to(target)
-        if wrong_shape_prediction.size() == target.size():
-            multi_scale_ssim(wrong_shape_prediction, target)
+        wrong_shape_x = torch.rand(size).to(y)
+        if wrong_shape_x.size() == y.size():
+            multi_scale_ssim(wrong_shape_x, y)
         else:
             with pytest.raises(AssertionError):
-                multi_scale_ssim(wrong_shape_prediction, target)
+                multi_scale_ssim(wrong_shape_x, y)
     scale_weights = torch.rand(2, 2)
     with pytest.raises(AssertionError):
-        multi_scale_ssim(prediction, target, scale_weights=scale_weights)
+        multi_scale_ssim(x, y, scale_weights=scale_weights)
 
 
 def test_multi_scale_ssim_check_available_dimensions() -> None:
-    custom_prediction = torch.rand(256, 256)
-    custom_target = torch.rand(256, 256)
+    custom_x = torch.rand(256, 256)
+    custom_y = torch.rand(256, 256)
     for _ in range(10):
-        if custom_prediction.dim() < 5:
+        if custom_x.dim() < 5:
             try:
-                multi_scale_ssim(custom_prediction, custom_target)
+                multi_scale_ssim(custom_x, custom_y)
             except Exception as e:
                 pytest.fail(f"Unexpected error occurred: {e}")
         else:
             with pytest.raises(AssertionError):
-                multi_scale_ssim(custom_prediction, custom_target)
-        custom_prediction.unsqueeze_(0)
-        custom_target.unsqueeze_(0)
+                multi_scale_ssim(custom_x, custom_y)
+
+        custom_x.unsqueeze_(0)
+        custom_y.unsqueeze_(0)
 
 
-def test_multi_scale_ssim_raises_if_tensors_have_different_types(prediction: torch.Tensor,
-                                                                 target: torch.Tensor) -> None:
-    wrong_type_prediction = list(range(10))
+def test_multi_scale_ssim_raises_if_tensors_have_different_types(x, y) -> None:
+    wrong_type_x = list(range(10))
     with pytest.raises(AssertionError):
-        multi_scale_ssim(wrong_type_prediction, target)
+        multi_scale_ssim(wrong_type_x, y)
     wrong_type_scale_weights = True
     with pytest.raises(AssertionError):
-        multi_scale_ssim(prediction, target, scale_weights=wrong_type_scale_weights)
+        multi_scale_ssim(x, y, scale_weights=wrong_type_scale_weights)
 
 
-def test_multi_scale_ssim_check_kernel_size_is_passed(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_multi_scale_ssim_check_kernel_size_is_passed(x, y) -> None:
     kernel_sizes = list(range(0, 13))
     for kernel_size in kernel_sizes:
         if kernel_size % 2:
-            multi_scale_ssim(prediction, target, kernel_size=kernel_size)
+            multi_scale_ssim(x, y, kernel_size=kernel_size)
         else:
             with pytest.raises(AssertionError):
-                multi_scale_ssim(prediction, target, kernel_size=kernel_size)
+                multi_scale_ssim(x, y, kernel_size=kernel_size)
 
 
-def test_ms_ssim_raises_if_kernel_size_greater_than_image(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor],
-                                                          device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ms_ssim_raises_if_kernel_size_greater_than_image(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     kernel_size = 11
     levels = 5
     min_size = (kernel_size - 1) * 2 ** (levels - 1) + 1
-    wrong_size_prediction = prediction[:, :, :min_size - 1, :min_size - 1]
-    wrong_size_target = target[:, :, :min_size - 1, :min_size - 1]
+    wrong_size_x = x[:, :, :min_size - 1, :min_size - 1]
+    wrong_size_y = y[:, :, :min_size - 1, :min_size - 1]
     with pytest.raises(ValueError):
-        multi_scale_ssim(wrong_size_prediction, wrong_size_target, kernel_size=kernel_size)
+        multi_scale_ssim(wrong_size_x, wrong_size_y, kernel_size=kernel_size)
 
 
 def test_multi_scale_ssim_raise_if_wrong_value_is_estimated(test_images: Tuple[torch.Tensor, torch.Tensor],
                                                             scale_weights: List, device: str) -> None:
-    for prediction, target in test_images:
-        piq_ms_ssim = multi_scale_ssim(prediction.to(device), target.to(device), kernel_size=11, kernel_sigma=1.5,
+    for x, y in test_images:
+        piq_ms_ssim = multi_scale_ssim(x.to(device), y.to(device), kernel_size=11, kernel_sigma=1.5,
                                        data_range=255, reduction='none', scale_weights=scale_weights)
-        tf_prediction = tf.convert_to_tensor(prediction.permute(0, 2, 3, 1).numpy())
-        tf_target = tf.convert_to_tensor(target.permute(0, 2, 3, 1).numpy())
+        tf_x = tf.convert_to_tensor(x.permute(0, 2, 3, 1).numpy())
+        tf_y = tf.convert_to_tensor(y.permute(0, 2, 3, 1).numpy())
         with tf.device('/CPU'):
-            tf_ms_ssim = torch.tensor(tf.image.ssim_multiscale(tf_prediction, tf_target, max_val=255,
+            tf_ms_ssim = torch.tensor(tf.image.ssim_multiscale(tf_x, tf_y, max_val=255,
                                                                power_factors=scale_weights).numpy()).to(device)
         match_accuracy = 1e-5 + 1e-8
         assert torch.allclose(piq_ms_ssim, tf_ms_ssim, rtol=0, atol=match_accuracy), \
@@ -425,56 +418,53 @@ def test_multi_scale_ssim_raise_if_wrong_value_is_estimated(test_images: Tuple[t
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_multi_scale_ssim_supports_different_data_ranges(
-        prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], data_range, device: str) -> None:
-    prediction, target = prediction_target_4d_5d
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
+def test_multi_scale_ssim_supports_different_data_ranges(x_y_4d_5d, data_range, device: str) -> None:
+    x, y = x_y_4d_5d
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
 
-    measure_scaled = multi_scale_ssim(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+    measure_scaled = multi_scale_ssim(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = multi_scale_ssim(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert (diff <= 1e-6).all(), f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_multi_scale_ssim_fails_for_incorrect_data_range(
-        prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_multi_scale_ssim_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        multi_scale_ssim(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        multi_scale_ssim(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
 
 
 # ================== Test class: `MultiScaleSSIMLoss` ==================
-def test_multi_scale_ssim_loss_grad(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
-    prediction.requires_grad_()
-    loss = MultiScaleSSIMLoss(data_range=1.)(prediction, target).mean()
+def test_multi_scale_ssim_loss_grad(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
+    x.requires_grad_()
+    loss = MultiScaleSSIMLoss(data_range=1.)(x, y).mean()
     loss.backward()
-    assert torch.isfinite(prediction.grad).all(), f'Expected finite gradient values, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'
 
 
-def test_multi_scale_ssim_loss_symmetry(prediction_target_4d_5d: Tuple[torch.Tensor, torch.Tensor],
-                                        device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_multi_scale_ssim_loss_symmetry(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     loss = MultiScaleSSIMLoss()
-    loss_value = loss(prediction, target)
-    reverse_loss_value = loss(target, prediction)
+    loss_value = loss(x, y)
+    reverse_loss_value = loss(y, x)
     assert (loss_value == reverse_loss_value).all(), \
         f'Expect: MS-SSIM(a, b) == MS-SSIM(b, a), got {loss_value} != {reverse_loss_value}'
 
 
-def test_multi_scale_ssim_loss_equality(target: torch.Tensor, device: str) -> None:
-    target = target.to(device)
-    prediction = target.clone()
-    loss = MultiScaleSSIMLoss()(prediction, target)
+def test_multi_scale_ssim_loss_equality(y, device: str) -> None:
+    y = y.to(device)
+    x = y.clone()
+    loss = MultiScaleSSIMLoss()(x, y)
     assert (loss.abs() <= 1e-6).all(), f'If equal tensors are passed SSIM loss must be equal to 0 ' \
                                        f'(considering floating point operation error up to 1 * 10^-6), got {loss}'
 
@@ -488,85 +478,80 @@ def test_multi_scale_ssim_loss_is_less_or_equal_to_one(ones_zeros_4d_5d: Tuple[t
     assert (loss <= 1).all(), f'MS-SSIM loss must be <= 1, got {loss}'
 
 
-def test_multi_scale_ssim_loss_raises_if_tensors_have_different_shapes(prediction_target_4d_5d: Tuple[torch.Tensor,
-                                                                                                      torch.Tensor],
-                                                                       device: str) -> None:
-    target = prediction_target_4d_5d[1].to(device)
+def test_multi_scale_ssim_loss_raises_if_tensors_have_different_shapes(x_y_4d_5d, device: str) -> None:
+    y = x_y_4d_5d[1].to(device)
     dims = [[3], [2, 3], [161, 162], [161, 162]]
-    if target.dim() == 5:
+    if y.dim() == 5:
         dims += [[2, 3]]
     for size in list(itertools.product(*dims)):
-        wrong_shape_prediction = torch.rand(size).to(target)
-        if wrong_shape_prediction.size() == target.size():
-            MultiScaleSSIMLoss()(wrong_shape_prediction, target)
+        wrong_shape_x = torch.rand(size).to(y)
+        if wrong_shape_x.size() == y.size():
+            MultiScaleSSIMLoss()(wrong_shape_x, y)
         else:
             with pytest.raises(AssertionError):
-                MultiScaleSSIMLoss()(wrong_shape_prediction, target)
+                MultiScaleSSIMLoss()(wrong_shape_x, y)
+
     scale_weights = torch.rand(2, 2)
     with pytest.raises(AssertionError):
-        MultiScaleSSIMLoss(scale_weights=scale_weights)(prediction, target)
+        MultiScaleSSIMLoss(scale_weights=scale_weights)(x, y)
 
 
 def test_multi_scale_ssim_loss_check_available_dimensions() -> None:
-    custom_prediction = torch.rand(256, 256)
-    custom_target = torch.rand(256, 256)
+    custom_x = torch.rand(256, 256)
+    custom_y = torch.rand(256, 256)
     for _ in range(10):
-        if custom_prediction.dim() < 5:
+        if custom_x.dim() < 5:
             try:
-                MultiScaleSSIMLoss()(custom_prediction, custom_target)
+                MultiScaleSSIMLoss()(custom_x, custom_y)
             except Exception as e:
                 pytest.fail(f"Unexpected error occurred: {e}")
         else:
             with pytest.raises(AssertionError):
-                MultiScaleSSIMLoss()(custom_prediction, custom_target)
-        custom_prediction.unsqueeze_(0)
-        custom_target.unsqueeze_(0)
+                MultiScaleSSIMLoss()(custom_x, custom_y)
+        custom_x.unsqueeze_(0)
+        custom_y.unsqueeze_(0)
 
 
-def test_multi_scale_ssim_loss_raises_if_tensors_have_different_types(prediction: torch.Tensor,
-                                                                      target: torch.Tensor) -> None:
-    wrong_type_prediction = list(range(10))
+def test_multi_scale_ssim_loss_raises_if_tensors_have_different_types(x, y) -> None:
+    wrong_type_y = list(range(10))
     with pytest.raises(AssertionError):
-        MultiScaleSSIMLoss()(wrong_type_prediction, target)
+        MultiScaleSSIMLoss()(wrong_type_y, y)
     wrong_type_scale_weights = True
     with pytest.raises(AssertionError):
-        MultiScaleSSIMLoss(scale_weights=wrong_type_scale_weights)(prediction, target)
+        MultiScaleSSIMLoss(scale_weights=wrong_type_scale_weights)(x, y)
 
 
-def test_multi_scale_ssim_loss_raises_if_wrong_kernel_size_is_passed(prediction: torch.Tensor,
-                                                                     target: torch.Tensor) -> None:
+def test_multi_scale_ssim_loss_raises_if_wrong_kernel_size_is_passed(x, y) -> None:
     kernel_sizes = list(range(0, 13))
     for kernel_size in kernel_sizes:
         if kernel_size % 2:
-            MultiScaleSSIMLoss(kernel_size=kernel_size)(prediction, target)
+            MultiScaleSSIMLoss(kernel_size=kernel_size)(x, y)
         else:
             with pytest.raises(AssertionError):
-                MultiScaleSSIMLoss(kernel_size=kernel_size)(prediction, target)
+                MultiScaleSSIMLoss(kernel_size=kernel_size)(x, y)
 
 
-def test_ms_ssim_loss_raises_if_kernel_size_greater_than_image(prediction_target_4d_5d: Tuple[torch.Tensor,
-                                                                                              torch.Tensor],
-                                                               device: str) -> None:
-    prediction = prediction_target_4d_5d[0].to(device)
-    target = prediction_target_4d_5d[1].to(device)
+def test_ms_ssim_loss_raises_if_kernel_size_greater_than_image(x_y_4d_5d, device: str) -> None:
+    x = x_y_4d_5d[0].to(device)
+    y = x_y_4d_5d[1].to(device)
     kernel_size = 11
     levels = 5
     min_size = (kernel_size - 1) * 2 ** (levels - 1) + 1
-    wrong_size_prediction = prediction[:, :, :min_size - 1, :min_size - 1]
-    wrong_size_target = target[:, :, :min_size - 1, :min_size - 1]
+    wrong_size_x = x[:, :, :min_size - 1, :min_size - 1]
+    wrong_size_y = y[:, :, :min_size - 1, :min_size - 1]
     with pytest.raises(ValueError):
-        MultiScaleSSIMLoss(kernel_size=kernel_size)(wrong_size_prediction, wrong_size_target)
+        MultiScaleSSIMLoss(kernel_size=kernel_size)(wrong_size_x, wrong_size_y)
 
 
 def test_multi_scale_ssim_loss_raise_if_wrong_value_is_estimated(test_images: List, scale_weights: List,
                                                                  device: str) -> None:
-    for prediction, target in test_images:
+    for x, y in test_images:
         piq_loss = MultiScaleSSIMLoss(kernel_size=11, kernel_sigma=1.5, data_range=255, scale_weights=scale_weights)
-        piq_ms_ssim_loss = piq_loss(prediction.to(device), target.to(device))
-        tf_prediction = tf.convert_to_tensor(prediction.permute(0, 2, 3, 1).numpy())
-        tf_target = tf.convert_to_tensor(target.permute(0, 2, 3, 1).numpy())
+        piq_ms_ssim_loss = piq_loss(x.to(device), y.to(device))
+        tf_x = tf.convert_to_tensor(x.permute(0, 2, 3, 1).numpy())
+        tf_y = tf.convert_to_tensor(y.permute(0, 2, 3, 1).numpy())
         with tf.device('/CPU'):
-            tf_ms_ssim = torch.tensor(tf.image.ssim_multiscale(tf_prediction, tf_target,
+            tf_ms_ssim = torch.tensor(tf.image.ssim_multiscale(tf_x, tf_y,
                                                                power_factors=scale_weights,
                                                                max_val=255).numpy()).mean().to(device)
         match_accuracy = 1e-5 + 1e-8

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -5,18 +5,18 @@ from piq import TVLoss, total_variation
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(4, 3, 256, 256)
 
 
 # ================== Test method: `total_variation` ==================
-def test_tv_works(prediction: torch.Tensor) -> None:
+def test_tv_works(x) -> None:
     for mode in ['l2', 'l1', 'l2_squared']:
-        measure = total_variation(prediction, norm_type=mode, reduction='none')
+        measure = total_variation(x, norm_type=mode, reduction='none')
         assert (measure > 0).all()
     with pytest.raises(ValueError):
         wrong_mode = 'DEADBEEF'
-        total_variation(prediction, norm_type=wrong_mode)
+        total_variation(x, norm_type=wrong_mode)
 
 
 # ================== Test class: `TVLoss` ==================
@@ -24,35 +24,35 @@ def test_tv_loss_init() -> None:
     TVLoss()
 
 
-def test_tv_loss_greater_than_zero(prediction: torch.Tensor) -> None:
+def test_tv_loss_greater_than_zero(x) -> None:
     for mode in ['l2', 'l1', 'l2_squared']:
-        res = TVLoss(norm_type=mode)(prediction)
+        res = TVLoss(norm_type=mode)(x)
         assert res > 0
 
 
 def test_tv_loss_raises_if_tensors_have_different_types() -> None:
-    wrong_type_prediction = list(range(10))
+    wrong_type_ = list(range(10))
     with pytest.raises(AssertionError):
-        TVLoss()(wrong_type_prediction)
+        TVLoss()(wrong_type_)
 
 
 def test_tv_loss_check_available_dimensions() -> None:
-    custom_prediction = torch.rand(256, 256)
+    custom_x = torch.rand(256, 256)
     for _ in range(10):
-        if custom_prediction.dim() < 5:
-            TVLoss()(custom_prediction)
+        if custom_x.dim() < 5:
+            TVLoss()(custom_x)
         else:
             with pytest.raises(AssertionError):
-                TVLoss()(custom_prediction)
-        custom_prediction.unsqueeze_(0)
+                TVLoss()(custom_x)
+        custom_x.unsqueeze_(0)
 
 
 def test_tv_loss_for_known_answer():
     # Tensor with `l1` TV = (10 - 1) * 2  * 2 = 36
-    prediction = torch.eye(10).reshape((1, 1, 10, 10))
-    prediction.requires_grad_()
+    x = torch.eye(10).reshape((1, 1, 10, 10))
+    x.requires_grad_()
     loss = TVLoss(norm_type='l1')
-    measure = loss(prediction)
+    measure = loss(x)
     measure.backward()
     assert measure == 36., f'TV for this tensors must be 36., got {measure}'
-    assert torch.isfinite(prediction.grad).all(), f'Expected finite gradient values, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), f'Expected finite gradient values, got {x.grad}'

--- a/tests/test_vif.py
+++ b/tests/test_vif.py
@@ -7,74 +7,73 @@ from skimage.io import imread
 
 
 @pytest.fixture(scope='module')
-def prediction() -> torch.Tensor:
+def x() -> torch.Tensor:
     return torch.rand(4, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def target() -> torch.Tensor:
+def y() -> torch.Tensor:
     return torch.rand(4, 3, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def prediction_1d() -> torch.Tensor:
+def x_1d() -> torch.Tensor:
     return torch.rand(4, 1, 256, 256)
 
 
 @pytest.fixture(scope='module')
-def target_1d() -> torch.Tensor:
+def y_1d() -> torch.Tensor:
     return torch.rand(4, 1, 256, 256)
 
 
 # ================== Test function: `vif_p` ==================
 def test_vif_p(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    vif_p(prediction.to(device), target.to(device), data_range=1.)
+    x, y = input_tensors
+    vif_p(x.to(device), y.to(device), data_range=1.)
 
 
-def test_vif_p_one_for_equal_tensors(prediction: torch.Tensor) -> None:
-    target = prediction.clone()
-    measure = vif_p(prediction, target)
+def test_vif_p_one_for_equal_tensors(x) -> None:
+    y = x.clone()
+    measure = vif_p(x, y)
     assert torch.isclose(measure, torch.tensor(1.0)), f'VIF for equal tensors shouls be 1.0, got {measure}.'
 
 
 def test_vif_p_works_for_zeros_tensors() -> None:
-    prediction = torch.zeros(4, 3, 256, 256)
-    target = torch.zeros(4, 3, 256, 256)
-    measure = vif_p(prediction, target, data_range=1.)
+    x = torch.zeros(4, 3, 256, 256)
+    y = torch.zeros(4, 3, 256, 256)
+    measure = vif_p(x, y, data_range=1.)
     assert torch.isclose(measure, torch.tensor(1.0)), f'VIF for 2 zero tensors shouls be 1.0, got {measure}.'
 
 
 def test_vif_p_fails_for_small_images() -> None:
-    prediction = torch.rand(2, 3, 32, 32)
-    target = torch.rand(2, 3, 32, 32)
+    x = torch.rand(2, 3, 32, 32)
+    y = torch.rand(2, 3, 32, 32)
     with pytest.raises(ValueError):
-        vif_p(prediction, target)
+        vif_p(x, y)
 
 
 @pytest.mark.parametrize(
     "data_range", [128, 255],
 )
-def test_vif_supports_different_data_ranges(
-        prediction: torch.Tensor, target: torch.Tensor, data_range, device: str) -> None:
-    prediction_scaled = (prediction * data_range).type(torch.uint8)
-    target_scaled = (target * data_range).type(torch.uint8)
-    measure_scaled = vif_p(prediction_scaled.to(device), target_scaled.to(device), data_range=data_range)
+def test_vif_supports_different_data_ranges(x, y, data_range, device: str) -> None:
+    x_scaled = (x * data_range).type(torch.uint8)
+    y_scaled = (y * data_range).type(torch.uint8)
+    measure_scaled = vif_p(x_scaled.to(device), y_scaled.to(device), data_range=data_range)
     measure = vif_p(
-        prediction_scaled.to(device) / float(data_range),
-        target_scaled.to(device) / float(data_range),
+        x_scaled.to(device) / float(data_range),
+        y_scaled.to(device) / float(data_range),
         data_range=1.0
     )
     diff = torch.abs(measure_scaled - measure)
     assert diff <= 1e-5, f'Result for same tensor with different data_range should be the same, got {diff}'
 
 
-def test_vif_fails_for_incorrect_data_range(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_vif_fails_for_incorrect_data_range(x, y, device: str) -> None:
     # Scale to [0, 255]
-    prediction_scaled = (prediction * 255).type(torch.uint8)
-    target_scaled = (target * 255).type(torch.uint8)
+    x_scaled = (x * 255).type(torch.uint8)
+    y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
-        vif_p(prediction_scaled.to(device), target_scaled.to(device), data_range=1.0)
+        vif_p(x_scaled.to(device), y_scaled.to(device), data_range=1.0)
 
 
 def test_vif_simmular_to_matlab_implementation():
@@ -102,50 +101,50 @@ def test_vif_simmular_to_matlab_implementation():
 
 
 # ================== Test class: `VIFLoss` ==================
-def test_vif_loss_forward(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
+def test_vif_loss_forward(x, y, device: str) -> None:
     loss = VIFLoss()
-    loss(prediction.to(device), target.to(device))
+    loss(x.to(device), y.to(device))
 
     
-def test_vif_loss_zero_for_equal_tensors(prediction: torch.Tensor):
+def test_vif_loss_zero_for_equal_tensors(x):
     loss = VIFLoss()
-    target = prediction.clone()
-    measure = loss(prediction, target)
+    y = x.clone()
+    measure = loss(x, y)
     assert torch.isclose(measure, torch.tensor(0.), atol=1e-6), f'VIF for equal tensors must be 0, got {measure}'
 
 
-def test_vif_loss_reduction(prediction: torch.Tensor, target: torch.Tensor) -> None:
+def test_vif_loss_reduction(x, y) -> None:
     loss = VIFLoss(reduction='mean')
-    measure = loss(prediction, target)
+    measure = loss(x, y)
     assert measure.dim() == 0, f'VIF with `mean` reduction must return 1 number, got {len(measure)}'
 
     loss = VIFLoss(reduction='sum')
-    measure = loss(prediction, target)
+    measure = loss(x, y)
     assert measure.dim() == 0, f'VIF with `mean` reduction must return 1 number, got {len(measure)}'
 
     loss = VIFLoss(reduction='none')
-    measure = loss(prediction, target)
-    assert len(measure) == prediction.size(0), \
+    measure = loss(x, y)
+    assert len(measure) == x.size(0), \
         f'VIF with `none` reduction must have length equal to number of images, got {len(measure)}'
     
     loss = VIFLoss(reduction='random string')
     with pytest.raises(KeyError):
-        loss(prediction, target)
+        loss(x, y)
 
 
 NONE_GRAD_ERR_MSG = 'Expected non None gradient of leaf variable'
 
 
-def test_vif_loss_computes_grad(prediction: torch.Tensor, target: torch.Tensor, device: str) -> None:
-    prediction.requires_grad_()
-    loss_value = VIFLoss()(prediction.to(device), target.to(device))
+def test_vif_loss_computes_grad(x, y, device: str) -> None:
+    x.requires_grad_()
+    loss_value = VIFLoss()(x.to(device), y.to(device))
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG
 
 
 def test_vif_loss_computes_grad_for_zeros_tensors() -> None:
-    prediction = torch.zeros(4, 3, 256, 256, requires_grad=True)
-    target = torch.zeros(4, 3, 256, 256)
-    loss_value = VIFLoss()(prediction, target)
+    x = torch.zeros(4, 3, 256, 256, requires_grad=True)
+    y = torch.zeros(4, 3, 256, 256)
+    loss_value = VIFLoss()(x, y)
     loss_value.backward()
-    assert prediction.grad is not None, NONE_GRAD_ERR_MSG
+    assert x.grad is not None, NONE_GRAD_ERR_MSG

--- a/tests/test_vsi.py
+++ b/tests/test_vsi.py
@@ -6,9 +6,9 @@ from typing import Tuple
 
 # ================== Test function: `vsi` ==================
 def test_vsi_to_be_one_for_identical_inputs(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, _ = input_tensors
-    index = vsi(prediction.to(device), prediction.to(device), data_range=1., reduction='none')
-    index_255 = vsi(prediction.to(device) * 255, prediction.to(device) * 255, data_range=255, reduction='none')
+    x, _ = input_tensors
+    index = vsi(x.to(device), x.to(device), data_range=1., reduction='none')
+    index_255 = vsi(x.to(device) * 255, x.to(device) * 255, data_range=255, reduction='none')
     assert torch.allclose(index, torch.ones_like(index, device=device)), \
         f'Expected index to be equal 1, got {index}'
     assert torch.allclose(index_255, torch.ones_like(index_255, device=device)), \
@@ -16,9 +16,9 @@ def test_vsi_to_be_one_for_identical_inputs(input_tensors: Tuple[torch.Tensor, t
 
 
 def test_vsi_symmetry(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    result = vsi(prediction.to(device), target.to(device), data_range=1., reduction='none')
-    result_sym = vsi(target.to(device), prediction.to(device), data_range=1., reduction='none')
+    x, y = input_tensors
+    result = vsi(x.to(device), y.to(device), data_range=1., reduction='none')
+    result_sym = vsi(y.to(device), x.to(device), data_range=1., reduction='none')
     assert torch.allclose(result_sym, result), f'Expected the same results, got {result} and {result_sym}'
 
 
@@ -35,9 +35,9 @@ def test_vsi_zeros_ones_inputs(device: str) -> None:
 
 
 def test_vsi_compare_with_matlab(device: str) -> None:
-    prediction = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1)
-    target = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1)
-    predicted_score = vsi(prediction.to(device), target.to(device), data_range=255, reduction='none')
+    x = torch.tensor(imread('tests/assets/I01.BMP')).permute(2, 0, 1)
+    y = torch.tensor(imread('tests/assets/i01_01_5.bmp')).permute(2, 0, 1)
+    predicted_score = vsi(x.to(device), y.to(device), data_range=255, reduction='none')
     target_score = torch.tensor([0.96405]).to(predicted_score)
     assert torch.allclose(predicted_score, target_score), f'Expected result similar to MATLAB,' \
                                                           f'got diff{predicted_score - target_score}'
@@ -45,18 +45,18 @@ def test_vsi_compare_with_matlab(device: str) -> None:
 
 # ================== Test class: `VSILoss` =================
 def test_vsi_loss(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, target = input_tensors
-    prediction.requires_grad_()
-    loss = VSILoss(data_range=1.)(prediction.to(device), target.to(device))
+    x, y = input_tensors
+    x.requires_grad_()
+    loss = VSILoss(data_range=1.)(x.to(device), y.to(device))
     loss.backward()
-    assert torch.isfinite(prediction.grad).all(), \
-        f'Expected finite gradient values after back propagation, got {prediction.grad}'
+    assert torch.isfinite(x.grad).all(), \
+        f'Expected finite gradient values after back propagation, got {x.grad}'
 
 
 def test_vsi_loss_zero_for_equal_input(input_tensors: Tuple[torch.Tensor, torch.Tensor], device: str) -> None:
-    prediction, _ = input_tensors
-    target = prediction.clone()
-    prediction.requires_grad_()
-    loss = VSILoss(data_range=1.)(prediction.to(device), target.to(device))
+    x, _ = input_tensors
+    y = x.clone()
+    x.requires_grad_()
+    loss = VSILoss(data_range=1.)(x.to(device), y.to(device))
     assert torch.isclose(loss, torch.zeros_like(loss)), \
         f'Expected loss equals zero for identical inputs, got {loss}'


### PR DESCRIPTION
Unification of tensor names for all metrics, measures and losses.

Closes #192 

## Proposed Changes

  - `prediction` -> `x`
  - `target` -> `y`
  - Fixes of typos and formatting