### PR TITLE
speed up CI

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -25,16 +25,14 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip
-        uses: actions/cache@v1
+      - name: Cache python
+        id: cache-python
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/pip # This path is specific to Ubuntu
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ matrix.torchvision-version }}-${{ hashFiles('requirements.txt') }}
       - name: Install dependencies
+        if: steps.cache-python.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install torchvision==${{ matrix.torchvision-version }}


### PR DESCRIPTION
## Proposed Changes

Speed up CI by caching python + installed dependencies

upd. it seems that your cache is too large. 1+ Gb for each element in the matrix. Github gives you only 5 Gb in cache, so only 4/6 runs could be cached, others would still require install. This still would save ~8 mins each time, so merge if it looks good to you