### PR TITLE
Re-write function for patch cropping to return an iterator

### DIFF
--- a/piq/pieapp.py
+++ b/piq/pieapp.py
@@ -199,9 +199,15 @@ class PieAPP(_Loss):
         """
         # Rescale to [0, 255] range on which models was trained
         x = x / float(self.data_range) * 255
-        x_patches = crop_patches(x, size=64, stride=self.stride)
+        x_patches_generator = crop_patches(x, size=64, stride=self.stride)
 
+        features, weights = [], []
         with torch.autograd.set_grad_enabled(self.enable_grad):
-            features, weights = self.model(x_patches)
+            for x_patches in x_patches_generator:
+                features_weights = self.model(x_patches)
+                features.append(features_weights[0])
+                weights.append(features_weights[1])
+        features = torch.cat(features, dim=0)
+        weights = torch.cat(weights, dim=0)
 
         return features, weights

--- a/tests/test_pieapp.py
+++ b/tests/test_pieapp.py
@@ -78,3 +78,10 @@ def test_pieapp_fails_for_incorrect_data_range(x, y, device: str) -> None:
     y_scaled = (y * 255).type(torch.uint8)
     with pytest.raises(AssertionError):
         PieAPP(data_range=1.0, stride=27)(x_scaled.to(device), y_scaled.to(device))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="This test is only relevant for GPU")
+def test_pieapp_supports_dense_sampling(x, y,) -> None:
+    x = torch.rand(2, 3, 256, 256)
+    y = torch.rand(2, 3, 256, 256)
+    PieAPP(data_range=1.0, stride=5)(x.cuda(), y.cuda())


### PR DESCRIPTION
Closes #282 

## Proposed Changes
  - Changed function to iterate over image patches instead f generating all of them at once.
 
**Pros:**
Memory consumption is significantly reduced, especially for large images

**Cons:** 
Inference time is also significantly increased. 

After internal discussion decided to leave everything as is. 
For large images it's recommended to use higher values of PieAPP `stride` parameter. 
