### PR TITLE
GPU-based IW-SSIM processing 

### DIFF
--- a/piq/iw_ssim.py
+++ b/piq/iw_ssim.py
@@ -385,7 +385,7 @@ def _information_content(x: torch.Tensor, y: torch.Tensor, y_parent: torch.Tenso
 
     C_u = torch.matmul(Y.transpose(-2, -1), Y) / nexp
 
-    recommended_torch_version = _parse_version('1.9.0')
+    recommended_torch_version = _parse_version('1.10.0')
     torch_version = _parse_version(torch.__version__)
     if len(torch_version) != 0 and torch_version >= recommended_torch_version:
         eig_values, eig_vectors = torch.linalg.eigh(C_u)

--- a/piq/iw_ssim.py
+++ b/piq/iw_ssim.py
@@ -367,7 +367,7 @@ def _information_content(x: torch.Tensor, y: torch.Tensor, y_parent: torch.Tenso
         y_parent_up = _image_enlarge(y_parent)[:, :, :y.size(-2), :y.size(-1)]
         N = N + 1
 
-    Y = torch.zeros(y.size(0), y.size(1), nexp, N)
+    Y = torch.zeros(y.size(0), y.size(1), nexp, N, dtype=y.dtype, device=y.device)
 
     n = -1
     for ny in range(-Ly, Ly + 1):
@@ -385,7 +385,7 @@ def _information_content(x: torch.Tensor, y: torch.Tensor, y_parent: torch.Tenso
 
     C_u = torch.matmul(Y.transpose(-2, -1), Y) / nexp
 
-    recommended_torch_version = _parse_version('1.7.0')
+    recommended_torch_version = _parse_version('1.9.0')
     torch_version = _parse_version(torch.__version__)
     if len(torch_version) != 0 and torch_version >= recommended_torch_version:
         eig_values, eig_vectors = torch.linalg.eigh(C_u)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-torchvision>=0.6.1,!=0.9
+torchvision>=0.6.1,!=0.9.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-torchvision>=0.6.1
+torchvision>=0.6.1,!=0.9

--- a/tests/test_iw_ssim.py
+++ b/tests/test_iw_ssim.py
@@ -186,10 +186,10 @@ def test_iw_ssim_loss_raises_if_tensors_have_different_shapes(x_rand: torch.Tens
             with pytest.raises(AssertionError):
                 loss(wrong_shape_x.to(device), x_rand.to(device))
 
-    loss = InformationWeightedSSIMLoss(data_range=1., scale_weights=scale_weights)
+    loss = InformationWeightedSSIMLoss(data_range=1., scale_weights=scale_weights.to(device))
     loss(x_rand.to(device), y_rand.to(device))
     wrong_scale_weights = torch.rand(2, 2)
-    loss = InformationWeightedSSIMLoss(data_range=1., scale_weights=wrong_scale_weights)
+    loss = InformationWeightedSSIMLoss(data_range=1., scale_weights=wrong_scale_weights.to(device))
     with pytest.raises(ValueError):
         loss(x_rand.to(device), y_rand.to(device))
 


### PR DESCRIPTION
Closes #310

## Proposed Changes
- Add torch version handler
- Eliminate `torch==1.8.*` and `torchvision==0.9.*` from requirements
- In case of `torch==1.9.*` and `torchvision==0.10.*` use `torch.symeig` instead of `torch.linalg.eigh`
- Tested on GPU
