### PR TITLE
FSIM Optimisation to Reduce CPU Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # VSCode settings
 .vscode/
+
+# MacOS
+.DS_Store

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -209,10 +209,10 @@ def _scale_features(features: torch.Tensor) -> torch.Tensor:
                                    [0.471, 3.264], [0.012809, 0.703171], [0.218, 1.046],
                                    [-0.094876, 0.187459], [1.5e-005, 0.442057], [0.001272, 0.40803],
                                    [0.222, 1.042], [-0.115772, 0.162604], [1.6e-005, 0.444362],
-                                   [0.001374, 0.40243], [0.227, 0.996],
-                                   [-0.117188, 0.09832299999999999], [3e-005, 0.531903],
-                                   [0.001122, 0.369589], [0.228, 0.99], [-0.12243, 0.098658],
-                                   [2.8e-005, 0.530092], [0.001118, 0.370399]]).to(features)
+                                   [0.001374, 0.40243], [0.227, 0.996], [-0.117188, 0.09832299999999999],
+                                   [3e-005, 0.531903], [0.001122, 0.369589], [0.228, 0.99], [-0.12243, 0.098658],
+                                   [2.8e-005, 0.530092],
+                                   [0.001118, 0.370399]], device=features.device, dtype=features.dtype)
 
     scaled_features = lower_bound + (upper_bound - lower_bound) * (features - feature_ranges[..., 0]) / (
             feature_ranges[..., 1] - feature_ranges[..., 0])
@@ -236,5 +236,5 @@ def _score_svr(features: torch.Tensor) -> torch.Tensor:
     rho = -153.591
     sv.t_()
     kernel_features = _rbf_kernel(features=features, sv=sv, gamma=gamma)
-    score = kernel_features @ sv_coef.to(dtype=features.dtype)
+    score = kernel_features @ sv_coef.type(features.dtype)
     return score - rho

--- a/piq/brisque.py
+++ b/piq/brisque.py
@@ -172,7 +172,7 @@ def _aggd_parameters(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch
 
 def _natural_scene_statistics(luma: torch.Tensor, kernel_size: int = 7, sigma: float = 7. / 6) -> torch.Tensor:
     kernel = gaussian_filter(kernel_size=kernel_size,
-                             sigma=sigma, dtype=luma.dtype).view(1, 1, kernel_size, kernel_size).to(luma)
+                             sigma=sigma, dtype=luma.dtype, device=luma.device).view(1, 1, kernel_size, kernel_size)
     C = 1
     mu = F.conv2d(luma, kernel, padding=kernel_size // 2)
     mu_sq = mu ** 2

--- a/piq/dss.py
+++ b/piq/dss.py
@@ -174,7 +174,7 @@ def _dct_matrix(size: int, device: Optional[str] = None, dtype: Optional[type] =
     p = torch.arange(1, size, device=device, dtype=dtype).reshape((size - 1, 1))
     q = torch.arange(1, 2 * size, 2, device=device, dtype=dtype)
     return torch.cat((
-        math.sqrt(1 / size) * torch.ones((1, size)),
+        math.sqrt(1 / size) * torch.ones((1, size), device=device, dtype=dtype),
         math.sqrt(2 / size) * torch.cos(math.pi / (2 * size) * p * q)), 0)
 
 

--- a/piq/dss.py
+++ b/piq/dss.py
@@ -135,8 +135,8 @@ def _subband_similarity(x: torch.Tensor, y: torch.Tensor, first_term: bool,
     c = dc_coeff if first_term else ac_coeff
 
     # Compute local variance
-    kernel = gaussian_filter(kernel_size=kernel_size, sigma=sigma)
-    kernel = kernel.view(1, 1, kernel_size, kernel_size).to(x)
+    kernel = gaussian_filter(kernel_size=kernel_size, sigma=sigma, dtype=x.dtype, device=x.device)
+    kernel = kernel.view(1, 1, kernel_size, kernel_size)
     mu_x = F.conv2d(x, kernel, padding=kernel_size // 2)
     mu_y = F.conv2d(y, kernel, padding=kernel_size // 2)
 

--- a/piq/dss.py
+++ b/piq/dss.py
@@ -12,7 +12,7 @@ import torch
 
 import torch.nn.functional as F
 
-from typing import Union
+from typing import Union, Optional
 from torch.nn.modules.loss import _Loss
 
 from piq.utils import _validate_input, _reduce
@@ -162,7 +162,7 @@ def _subband_similarity(x: torch.Tensor, y: torch.Tensor, first_term: bool,
     return similarity
 
 
-def _dct_matrix(size: int, dtype: type = None, device: str = None) -> torch.Tensor:
+def _dct_matrix(size: int, device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r""" Computes the matrix coefficients for DCT transform using the following formula:
     https://fr.mathworks.com/help/images/discrete-cosine-transform.html
 

--- a/piq/dss.py
+++ b/piq/dss.py
@@ -84,7 +84,7 @@ def dss(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean',
     dct_y = _dct_decomp(y_lum, dct_size)
 
     # Create a Gaussian window that will be used to weight subbands scores
-    coords = torch.arange(1, dct_size + 1).to(x)
+    coords = torch.arange(1, dct_size + 1, dtype=x.dtype, device=x.device)
     weight = (coords - 0.5) ** 2
     weight = (- (weight.unsqueeze(0) + weight.unsqueeze(1)) / (2 * sigma_weight ** 2)).exp()
 
@@ -162,15 +162,17 @@ def _subband_similarity(x: torch.Tensor, y: torch.Tensor, first_term: bool,
     return similarity
 
 
-def _dct_matrix(size: int) -> torch.Tensor:
+def _dct_matrix(size: int, dtype: type = None, device: str = None) -> torch.Tensor:
     r""" Computes the matrix coefficients for DCT transform using the following formula:
     https://fr.mathworks.com/help/images/discrete-cosine-transform.html
 
     Args:
-       size : size of DCT matrix to create.  (`size`, `size`)
+        size : size of DCT matrix to create.  (`size`, `size`)
+        device: target device for generation
+        dtype: target data type for generation
     """
-    p = torch.arange(1, size).reshape((size - 1, 1))
-    q = torch.arange(1, 2 * size, 2)
+    p = torch.arange(1, size, device=device, dtype=dtype).reshape((size - 1, 1))
+    q = torch.arange(1, 2 * size, 2, device=device, dtype=dtype)
     return torch.cat((
         math.sqrt(1 / size) * torch.ones((1, size)),
         math.sqrt(2 / size) * torch.cos(math.pi / (2 * size) * p * q)), 0)
@@ -196,7 +198,7 @@ def _dct_decomp(x: torch.Tensor, dct_size: int = 8) -> torch.Tensor:
     blocks = blocks.view(bs, 1, -1, dct_size, dct_size)  # shape (bs, 1, block_num, N, N)
 
     # apply DCT transform
-    coeffs = _dct_matrix(dct_size).to(x)
+    coeffs = _dct_matrix(dct_size, device=x.device, dtype=x.dtype)
 
     blocks = coeffs @ blocks @ coeffs.t()  # @ does operation on last 2 channels only
 

--- a/piq/fsim.py
+++ b/piq/fsim.py
@@ -147,8 +147,6 @@ def _construct_filters(x: torch.Tensor, scales: int = 4, orientations: int = 4, 
     # Pre-compute some stuff to speed up filter construction
     grid_x, grid_y = get_meshgrid((H, W), device=x.device, dtype=x.dtype)
 
-    # Move grid to GPU early on, so that all math heavy stuff computes faster.
-    # grid_x, grid_y = grid_x.to(x), grid_y.to(x)
     radius = torch.sqrt(grid_x ** 2 + grid_y ** 2)
     theta = torch.atan2(-grid_y, grid_x)
 

--- a/piq/fsim.py
+++ b/piq/fsim.py
@@ -92,8 +92,8 @@ def fsim(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean',
     pc_y = _phase_congruency(y_lum, filters=filters, scales=scales, orientations=orientations, k=k)
 
     # Gradient maps
-    filter = scharr_filter(device=x_lum.device, dtype=x_lum.dtype)
-    kernels = torch.stack([filter, filter.transpose(-1, -2)])
+    sch_filter = scharr_filter(device=x_lum.device, dtype=x_lum.dtype)
+    kernels = torch.stack([sch_filter, sch_filter.transpose(-1, -2)])
     grad_map_x = gradient_map(x_lum, kernels)
     grad_map_y = gradient_map(y_lum, kernels)
 

--- a/piq/fsim.py
+++ b/piq/fsim.py
@@ -97,7 +97,7 @@ def fsim(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean',
     )
 
     # Gradient maps
-    kernels = torch.stack([scharr_filter(), scharr_filter().transpose(-1, -2)])
+    kernels = torch.stack([scharr_filter(), scharr_filter().transpose(-1, -2)]).to(x_lum)
     grad_map_x = gradient_map(x_lum, kernels)
     grad_map_y = gradient_map(y_lum, kernels)
 
@@ -308,7 +308,7 @@ def _phase_congruency(x: torch.Tensor, scales: int = 4, orientations: int = 4,
 
     sum_an2 = torch.sum(filters_ifft ** 2, dim=-3, keepdim=True)
 
-    sum_ai_aj = torch.zeros(N, orientations, 1, H, W).to(x)
+    sum_ai_aj = torch.zeros(N, orientations, 1, H, W, dtype=x.dtype, device=x.device)
     for s in range(scales - 1):
         sum_ai_aj = sum_ai_aj + (filters_ifft[:, :, s: s + 1] * filters_ifft[:, :, s + 1:]).sum(dim=-3, keepdim=True)
 

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -1,5 +1,5 @@
 r"""General purpose functions"""
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 import torch
 
 
@@ -9,7 +9,7 @@ def ifftshift(x: torch.Tensor) -> torch.Tensor:
     return torch.roll(x, shift, tuple(range(len(shift))))
 
 
-def get_meshgrid(size: Tuple[int, int], device: str = 'cpu', dtype: type = torch.float) -> torch.Tensor:
+def get_meshgrid(size: Tuple[int, int], device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Return coordinate grid matrices centered at zero point.
     Args:
         size: Shape of meshgrid to create

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -9,24 +9,28 @@ def ifftshift(x: torch.Tensor) -> torch.Tensor:
     return torch.roll(x, shift, tuple(range(len(shift))))
 
 
-def get_meshgrid(size: Tuple[int, int]) -> torch.Tensor:
+def get_meshgrid(size: Tuple[int, int], device: str = 'cpu', dtype: type = torch.float) -> torch.Tensor:
     r"""Return coordinate grid matrices centered at zero point.
     Args:
         size: Shape of meshgrid to create
+        device: device to use for creation
+        dtype: dtype to use for creation
+    Returns:
+        Meshgrid of size on device with dtype values.
     """
     if size[0] % 2:
         # Odd
-        x = torch.arange(-(size[0] - 1) / 2, size[0] / 2) / (size[0] - 1)
+        x = torch.arange(-(size[0] - 1) / 2, size[0] / 2, device=device, dtype=dtype) / (size[0] - 1)
     else:
         # Even
-        x = torch.arange(- size[0] / 2, size[0] / 2) / size[0]
+        x = torch.arange(- size[0] / 2, size[0] / 2, device=device, dtype=dtype) / size[0]
 
     if size[1] % 2:
         # Odd
-        y = torch.arange(-(size[1] - 1) / 2, size[1] / 2) / (size[1] - 1)
+        y = torch.arange(-(size[1] - 1) / 2, size[1] / 2, device=device, dtype=dtype) / (size[1] - 1)
     else:
         # Even
-        y = torch.arange(- size[1] / 2, size[1] / 2) / size[1]
+        y = torch.arange(- size[1] / 2, size[1] / 2, device=device, dtype=dtype) / size[1]
     return torch.meshgrid(x, y)
 
 

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -53,7 +53,7 @@ def gradient_map(x: torch.Tensor, kernels: torch.Tensor) -> torch.Tensor:
         Gradients of x per-channel with shape (N, C, H, W)
     """
     padding = kernels.size(-1) // 2
-    grads = torch.nn.functional.conv2d(x, kernels.to(x), padding=padding)
+    grads = torch.nn.functional.conv2d(x, kernels, padding=padding)
 
     return torch.sqrt(torch.sum(grads ** 2, dim=-3, keepdim=True))
 

--- a/piq/functional/filters.py
+++ b/piq/functional/filters.py
@@ -1,9 +1,10 @@
 r"""Filters for gradient computation, bluring, etc."""
 import torch
 import numpy as np
+from typing import Optional
 
 
-def haar_filter(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
+def haar_filter(kernel_size: int, device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Creates Haar kernel
 
     Args:
@@ -18,7 +19,7 @@ def haar_filter(kernel_size: int, device: str = None, dtype: type = None) -> tor
     return kernel.unsqueeze(0)
 
 
-def hann_filter(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
+def hann_filter(kernel_size: int, device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Creates  Hann kernel
     Args:
         kernel_size: size of the kernel
@@ -34,7 +35,8 @@ def hann_filter(kernel_size: int, device: str = None, dtype: type = None) -> tor
     return kernel.view(1, kernel_size, kernel_size) / kernel.sum()
 
 
-def gaussian_filter(kernel_size: int, sigma: float, device: str = None, dtype: torch.dtype = None) -> torch.Tensor:
+def gaussian_filter(kernel_size: int, sigma: float, device: Optional[str] = None,
+                    dtype: Optional[type] = None) -> torch.Tensor:
     r"""Returns 2D Gaussian kernel N(0,`sigma`^2)
     Args:
         size: Size of the kernel
@@ -55,7 +57,7 @@ def gaussian_filter(kernel_size: int, sigma: float, device: str = None, dtype: t
 
 
 # Gradient operator kernels
-def scharr_filter(device: str = None, dtype: type = None) -> torch.Tensor:
+def scharr_filter(device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Scharr kernel in X direction
 
     Args:
@@ -67,7 +69,7 @@ def scharr_filter(device: str = None, dtype: type = None) -> torch.Tensor:
     return torch.tensor([[[-3., 0., 3.], [-10., 0., 10.], [-3., 0., 3.]]], device=device, dtype=dtype) / 16
 
 
-def prewitt_filter(device: str = None, dtype: type = None) -> torch.Tensor:
+def prewitt_filter(device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Prewitt kernel in X direction
 
     Args:
@@ -78,7 +80,7 @@ def prewitt_filter(device: str = None, dtype: type = None) -> torch.Tensor:
     return torch.tensor([[[-1., 0., 1.], [-1., 0., 1.], [-1., 0., 1.]]], device=device, dtype=dtype) / 3
 
 
-def binomial_filter1d(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
+def binomial_filter1d(kernel_size: int, device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Creates 1D normalized binomial filter
 
     Args:
@@ -93,7 +95,7 @@ def binomial_filter1d(kernel_size: int, device: str = None, dtype: type = None) 
     return torch.tensor(kernel.c, dtype=dtype, device=device).view(1, 1, kernel_size)
 
 
-def average_filter2d(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
+def average_filter2d(kernel_size: int, device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Creates 2D normalized average filter
 
     Args:

--- a/piq/functional/filters.py
+++ b/piq/functional/filters.py
@@ -45,12 +45,16 @@ def gaussian_filter(kernel_size: int, sigma: float, dtype: torch.dtype = torch.f
 
 
 # Gradient operator kernels
-def scharr_filter() -> torch.Tensor:
+def scharr_filter(device: str = 'cpu', dtype: type = torch.float) -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Scharr kernel in X direction
+
+    Args:
+        device: device to use for filter generation
+        dtype: dtype to use for filter generation
     Returns:
         kernel: Tensor with shape (1, 3, 3)
     """
-    return torch.tensor([[[-3., 0., 3.], [-10., 0., 10.], [-3., 0., 3.]]]) / 16
+    return torch.tensor([[[-3., 0., 3.], [-10., 0., 10.], [-3., 0., 3.]]], device=device, dtype=dtype) / 16
 
 
 def prewitt_filter() -> torch.Tensor:

--- a/piq/functional/filters.py
+++ b/piq/functional/filters.py
@@ -3,38 +3,48 @@ import torch
 import numpy as np
 
 
-def haar_filter(kernel_size: int) -> torch.Tensor:
+def haar_filter(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Creates Haar kernel
+
+    Args:
+        kernel_size: size of the kernel
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         kernel: Tensor with shape (1, kernel_size, kernel_size)
     """
-    kernel = torch.ones((kernel_size, kernel_size)) / kernel_size
+    kernel = torch.ones((kernel_size, kernel_size), device=device, dtype=dtype) / kernel_size
     kernel[kernel_size // 2:, :] = - kernel[kernel_size // 2:, :]
     return kernel.unsqueeze(0)
 
 
-def hann_filter(kernel_size: int) -> torch.Tensor:
+def hann_filter(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Creates  Hann kernel
+    Args:
+        kernel_size: size of the kernel
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         kernel: Tensor with shape (1, kernel_size, kernel_size)
     """
     # Take bigger window and drop borders
-    window = torch.hann_window(kernel_size + 2, periodic=False)[1:-1]
+    window = torch.hann_window(kernel_size + 2, periodic=False, device=device, dtype=dtype)[1:-1]
     kernel = window[:, None] * window[None, :]
     # Normalize and reshape kernel
     return kernel.view(1, kernel_size, kernel_size) / kernel.sum()
 
 
-def gaussian_filter(kernel_size: int, sigma: float, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+def gaussian_filter(kernel_size: int, sigma: float, device: str = None, dtype: torch.dtype = None) -> torch.Tensor:
     r"""Returns 2D Gaussian kernel N(0,`sigma`^2)
     Args:
         size: Size of the kernel
         sigma: Std of the distribution
-        dtype: type of tensor to return
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         gaussian_kernel: Tensor with shape (1, kernel_size, kernel_size)
     """
-    coords = torch.arange(kernel_size, dtype=dtype)
+    coords = torch.arange(kernel_size, dtype=dtype, device=device)
     coords -= (kernel_size - 1) / 2.
 
     g = coords ** 2
@@ -45,47 +55,55 @@ def gaussian_filter(kernel_size: int, sigma: float, dtype: torch.dtype = torch.f
 
 
 # Gradient operator kernels
-def scharr_filter(device: str = 'cpu', dtype: type = torch.float) -> torch.Tensor:
+def scharr_filter(device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Scharr kernel in X direction
 
     Args:
-        device: device to use for filter generation
-        dtype: dtype to use for filter generation
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         kernel: Tensor with shape (1, 3, 3)
     """
     return torch.tensor([[[-3., 0., 3.], [-10., 0., 10.], [-3., 0., 3.]]], device=device, dtype=dtype) / 16
 
 
-def prewitt_filter() -> torch.Tensor:
+def prewitt_filter(device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Utility function that returns a normalized 3x3 Prewitt kernel in X direction
+
+    Args:
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         kernel: Tensor with shape (1, 3, 3)"""
-    return torch.tensor([[[-1., 0., 1.], [-1., 0., 1.], [-1., 0., 1.]]]) / 3
+    return torch.tensor([[[-1., 0., 1.], [-1., 0., 1.], [-1., 0., 1.]]], device=device, dtype=dtype) / 3
 
 
-def binomial_filter1d(kernel_size: int) -> torch.Tensor:
+def binomial_filter1d(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Creates 1D normalized binomial filter
 
     Args:
         kernel_size (int): kernel size
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
 
     Returns:
         Binomial kernel with shape (1, 1, kernel_size)
     """
     kernel = np.poly1d([0.5, 0.5]) ** (kernel_size - 1)
-    return torch.tensor(kernel.c).view(1, 1, kernel_size)
+    return torch.tensor(kernel.c, dtype=dtype, device=device).view(1, 1, kernel_size)
 
 
-def average_filter2d(kernel_size: int) -> torch.Tensor:
+def average_filter2d(kernel_size: int, device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Creates 2D normalized average filter
 
     Args:
-        kernel_size (int):
+        kernel_size (int): kernel size
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
 
     Returns:
         kernel: Tensor with shape (1, kernel_size, kernel_size)
     """
-    window = torch.ones(kernel_size) / kernel_size
+    window = torch.ones(kernel_size, dtype=dtype, device=device) / kernel_size
     kernel = window[:, None] * window[None, :]
     return kernel.unsqueeze(0)

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -81,7 +81,8 @@ def _gmsd(x: torch.Tensor, y: torch.Tensor,
     """
 
     # Compute grad direction
-    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(-1, -2)]).to(x)
+    p_filter = prewitt_filter(dtype=x.dtype, device=x.device)
+    kernels = torch.stack([p_filter, p_filter.transpose(-1, -2)])
     x_grad = gradient_map(x, kernels)
     y_grad = gradient_map(y, kernels)
 
@@ -181,10 +182,10 @@ def multi_scale_gmsd(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, fl
 
     # Values from the paper
     if scale_weights is None:
-        scale_weights = torch.tensor([0.096, 0.596, 0.289, 0.019], device=x.device)
+        scale_weights = torch.tensor([0.096, 0.596, 0.289, 0.019], device=x.device, dtype=x.dtype)
     else:
         # Normalize scale weights
-        scale_weights = (scale_weights / scale_weights.sum()).to(x)
+        scale_weights = (scale_weights / scale_weights.sum())
 
     # Check that input is big enough
     num_scales = scale_weights.size(0)

--- a/piq/gmsd.py
+++ b/piq/gmsd.py
@@ -81,7 +81,7 @@ def _gmsd(x: torch.Tensor, y: torch.Tensor,
     """
 
     # Compute grad direction
-    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(-1, -2)])
+    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(-1, -2)]).to(x)
     x_grad = gradient_map(x, kernels)
     y_grad = gradient_map(y, kernels)
 

--- a/piq/haarpsi.py
+++ b/piq/haarpsi.py
@@ -82,14 +82,15 @@ def haarpsi(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean',
     coefficients_x, coefficients_y = [], []
     for scale in range(scales):
         kernel_size = 2 ** (scale + 1)
-        kernels = torch.stack([haar_filter(kernel_size), haar_filter(kernel_size).transpose(-1, -2)])
+        h_filter = haar_filter(kernel_size, dtype=x.dtype, device=x.device)
+        kernels = torch.stack([h_filter, h_filter.transpose(-1, -2)])
 
         # Asymmetrical padding due to even kernel size. Matches MATLAB conv2(A, B, 'same')
         upper_pad = kernel_size // 2 - 1
         bottom_pad = kernel_size // 2
         pad_to_use = [upper_pad, bottom_pad, upper_pad, bottom_pad]
-        coeff_x = torch.nn.functional.conv2d(F.pad(x_yiq[:, : 1], pad=pad_to_use, mode='constant'), kernels.to(x))
-        coeff_y = torch.nn.functional.conv2d(F.pad(y_yiq[:, : 1], pad=pad_to_use, mode='constant'), kernels.to(y))
+        coeff_x = torch.nn.functional.conv2d(F.pad(x_yiq[:, : 1], pad=pad_to_use, mode='constant'), kernels)
+        coeff_y = torch.nn.functional.conv2d(F.pad(y_yiq[:, : 1], pad=pad_to_use, mode='constant'), kernels)
 
         coefficients_x.append(coeff_x)
         coefficients_y.append(coeff_y)

--- a/piq/isc.py
+++ b/piq/isc.py
@@ -60,7 +60,7 @@ def inception_score(features: torch.Tensor, num_splits: int = 10):
         partial_scores.append(torch.tensor(scores).mean().exp())
 
     partial_scores = torch.tensor(partial_scores)
-    return torch.mean(partial_scores).to(features), torch.std(partial_scores).to(features)
+    return torch.mean(partial_scores), torch.std(partial_scores)
 
 
 class IS(BaseFeatureMetric):

--- a/piq/iw_ssim.py
+++ b/piq/iw_ssim.py
@@ -86,11 +86,11 @@ def information_weighted_ssim(x: torch.Tensor, y: torch.Tensor, data_range: Unio
 
     blur_pad = math.ceil((kernel_size - 1) / 2)  # Ceil
     iw_pad = blur_pad - math.floor((blk_size - 1) / 2)  # floor
-    gauss_kernel = gaussian_filter(kernel_size, kernel_sigma).repeat(x.size(1), 1, 1, 1).to(x)
+    gauss_kernel = gaussian_filter(kernel_size, kernel_sigma, device=x.device, dtype=x.dtype).repeat(x.size(1), 1, 1, 1)
 
     # Size of the kernel size to build Laplacian pyramid
     pyramid_kernel_size = 5
-    bin_filter = binomial_filter1d(kernel_size=pyramid_kernel_size).to(x) * 2 ** 0.5
+    bin_filter = binomial_filter1d(kernel_size=pyramid_kernel_size, device=x.device, dtype=x.dtype) * 2 ** 0.5
 
     lo_x, x_diff_old = _pyr_step(x, bin_filter)
     lo_y, y_diff_old = _pyr_step(y, bin_filter)
@@ -319,7 +319,7 @@ def _information_content(x: torch.Tensor, y: torch.Tensor, y_parent: torch.Tenso
 
     EPS = torch.finfo(x.dtype).eps
     n_channels = x.size(1)
-    kernel = average_filter2d(kernel_size=kernel_size).repeat(x.size(1), 1, 1, 1).to(x)
+    kernel = average_filter2d(kernel_size=kernel_size, device=x.device, dtype=x.dtype).repeat(x.size(1), 1, 1, 1)
     padding_up = kernel.size(-1) // 2
     padding_down = kernel.size(-1) - padding_up
 
@@ -432,7 +432,7 @@ def _image_enlarge(x: torch.Tensor) -> torch.Tensor:
         Upscaled tensor.
     """
     t1 = F.interpolate(x, size=(int(4 * x.size(-2) - 3), int(4 * x.size(-1) - 3)), mode='bilinear', align_corners=False)
-    t2 = torch.zeros([x.size(0), 1, 4 * x.size(-2) - 1, 4 * x.size(-1) - 1]).to(x)
+    t2 = torch.zeros([x.size(0), 1, 4 * x.size(-2) - 1, 4 * x.size(-1) - 1], device=x.device, dtype=x.dtype)
     t2[:, :, 1: -1, 1:-1] = t1
     t2[:, :, 0, :] = 2 * t2[:, :, 1, :] - t2[:, :, 2, :]
     t2[:, :, -1, :] = 2 * t2[:, :, -2, :] - t2[:, :, -3, :]

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -86,7 +86,7 @@ def mdsi(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1., r
     x_lhm = rgb2lhm(x)
     y_lhm = rgb2lhm(y)
 
-    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(1, 2)]).to(x)
+    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(1, 2)]).to(x_lhm)
     gm_x = gradient_map(x_lhm[:, :1], kernels)
     gm_y = gradient_map(y_lhm[:, :1], kernels)
     gm_avg = gradient_map((x_lhm[:, :1] + y_lhm[:, :1]) / 2., kernels)

--- a/piq/mdsi.py
+++ b/piq/mdsi.py
@@ -86,7 +86,8 @@ def mdsi(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1., r
     x_lhm = rgb2lhm(x)
     y_lhm = rgb2lhm(y)
 
-    kernels = torch.stack([prewitt_filter(), prewitt_filter().transpose(1, 2)]).to(x_lhm)
+    p_filter = prewitt_filter(device=x_lhm.device, dtype=x_lhm.dtype)
+    kernels = torch.stack([p_filter, p_filter.transpose(1, 2)])
     gm_x = gradient_map(x_lhm[:, :1], kernels)
     gm_y = gradient_map(y_lhm[:, :1], kernels)
     gm_avg = gradient_map((x_lhm[:, :1] + y_lhm[:, :1]) / 2., kernels)

--- a/piq/ms_ssim.py
+++ b/piq/ms_ssim.py
@@ -65,14 +65,14 @@ def multi_scale_ssim(x: torch.Tensor, y: torch.Tensor, kernel_size: int = 11, ke
 
     if scale_weights is None:
         # Values from MS-SSIM the paper
-        scale_weights = torch.tensor([0.0448, 0.2856, 0.3001, 0.2363, 0.1333]).to(x)
+        scale_weights = torch.tensor([0.0448, 0.2856, 0.3001, 0.2363, 0.1333], dtype=x.dtype, device=x.device)
     else:
         # Normalize scale weights
-        scale_weights = (scale_weights / scale_weights.sum()).to(x)
+        scale_weights = (scale_weights / scale_weights.sum())
     if scale_weights.size(0) != scale_weights.numel():
         raise ValueError(f'Expected a vector of weights, got {scale_weights.dim()}D tensor')
 
-    kernel = gaussian_filter(kernel_size, kernel_sigma).repeat(x.size(1), 1, 1, 1).to(x)
+    kernel = gaussian_filter(kernel_size, kernel_sigma, device=x.device, dtype=x.dtype).repeat(x.size(1), 1, 1, 1)
 
     _compute_msssim = _multi_scale_ssim_complex if x.dim() == 5 else _multi_scale_ssim
     msssim_val = _compute_msssim(

--- a/piq/psnr.py
+++ b/piq/psnr.py
@@ -36,7 +36,7 @@ def psnr(x: torch.Tensor, y: torch.Tensor, data_range: Union[int, float] = 1.0,
 
     if (x.size(1) == 3) and convert_to_greyscale:
         # Convert RGB image to YIQ and take luminance: Y = 0.299 R + 0.587 G + 0.114 B
-        rgb_to_grey = torch.tensor([0.299, 0.587, 0.114]).view(1, -1, 1, 1).to(x)
+        rgb_to_grey = torch.tensor([0.299, 0.587, 0.114], device=x.device, dtype=x.dtype).view(1, -1, 1, 1)
         x = torch.sum(x * rgb_to_grey, dim=1, keepdim=True)
         y = torch.sum(y * rgb_to_grey, dim=1, keepdim=True)
 

--- a/piq/srsim.py
+++ b/piq/srsim.py
@@ -92,7 +92,7 @@ def srsim(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean',
     )
 
     # Gradient maps
-    kernels = torch.stack([scharr_filter(), scharr_filter().transpose(-1, -2)])
+    kernels = torch.stack([scharr_filter(), scharr_filter().transpose(-1, -2)]).to(x_lum)
     grad_map_x = gradient_map(x_lum, kernels)
     grad_map_y = gradient_map(y_lum, kernels)
 

--- a/piq/srsim.py
+++ b/piq/srsim.py
@@ -190,8 +190,10 @@ def _spectral_residual_visual_saliency(x: torch.Tensor, scale: float = 0.25, ker
     # Apply gaussian blur
     kernel = gaussian_filter(gaussian_size, sigma, device=saliency_map.device, dtype=saliency_map.dtype)
     if gaussian_size % 2 == 0:  # matlab pads upper and lower borders with 0s for even kernels
-        kernel = torch.cat((torch.zeros(1, 1, gaussian_size), kernel), 1)
-        kernel = torch.cat((torch.zeros(1, gaussian_size + 1, 1), kernel), 2)
+        kernel = torch.cat((torch.zeros(1, 1, gaussian_size,
+                            device=saliency_map.device, dtype=saliency_map.dtype), kernel), 1)
+        kernel = torch.cat((torch.zeros(1, gaussian_size + 1, 1,
+                            device=saliency_map.device, dtype=saliency_map.dtype), kernel), 2)
         gaussian_size += 1
     kernel = kernel.view(1, 1, gaussian_size, gaussian_size)
     saliency_map = F.conv2d(saliency_map, kernel, padding=(gaussian_size - 1) // 2)

--- a/piq/ssim.py
+++ b/piq/ssim.py
@@ -61,7 +61,7 @@ def ssim(x: torch.Tensor, y: torch.Tensor, kernel_size: int = 11, kernel_sigma: 
         x = F.avg_pool2d(x, kernel_size=f)
         y = F.avg_pool2d(y, kernel_size=f)
 
-    kernel = gaussian_filter(kernel_size, kernel_sigma).repeat(x.size(1), 1, 1, 1).to(y)
+    kernel = gaussian_filter(kernel_size, kernel_sigma, device=x.device, dtype=x.dtype).repeat(x.size(1), 1, 1, 1)
     _compute_ssim_per_channel = _ssim_per_channel_complex if x.dim() == 5 else _ssim_per_channel
     ssim_map, cs_map = _compute_ssim_per_channel(x=x, y=y, kernel=kernel, data_range=data_range, k1=k1, k2=k2)
     ssim_val = ssim_map.mean(1)

--- a/piq/vif.py
+++ b/piq/vif.py
@@ -69,8 +69,8 @@ def vif_p(x: torch.Tensor, y: torch.Tensor, sigma_n_sq: float = 2.0,
     x_vif, y_vif = 0, 0
     for scale in range(4):
         kernel_size = 2 ** (4 - scale) + 1
-        kernel = gaussian_filter(kernel_size, sigma=kernel_size / 5)
-        kernel = kernel.view(1, 1, kernel_size, kernel_size).to(x)
+        kernel = gaussian_filter(kernel_size, sigma=kernel_size / 5, device=x.device, dtype=x.dtype)
+        kernel = kernel.view(1, 1, kernel_size, kernel_size)
 
         if scale > 0:
             # Convolve and downsample

--- a/piq/vsi.py
+++ b/piq/vsi.py
@@ -7,7 +7,7 @@ References:
 """
 import warnings
 import functools
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional
 
 import torch
 from torch.nn.modules.loss import _Loss
@@ -244,7 +244,7 @@ def sdsp(x: torch.Tensor, data_range: Union[int, float] = 255, omega_0: float = 
 
 
 def _log_gabor(size: Tuple[int, int], omega_0: float, sigma_f: float,
-               device: str = None, dtype: type = None) -> torch.Tensor:
+               device: Optional[str] = None, dtype: Optional[type] = None) -> torch.Tensor:
     r"""Creates log Gabor filter
 
     Args:

--- a/piq/vsi.py
+++ b/piq/vsi.py
@@ -96,7 +96,8 @@ def vsi(x: torch.Tensor, y: torch.Tensor, reduction: str = 'mean', data_range: U
     y_lmn = avg_pool2d(y_lmn, kernel_size=kernel_size)
 
     # Calculate gradient map
-    kernels = torch.stack([scharr_filter(), scharr_filter().transpose(1, 2)]).to(x_lmn)
+    sch_filter = scharr_filter(device=x_lmn.device, dtype=x_lmn.dtype)
+    kernels = torch.stack([sch_filter, sch_filter.transpose(1, 2)])
     gm_x = gradient_map(x_lmn[:, :1], kernels)
     gm_y = gradient_map(y_lmn[:, :1], kernels)
 
@@ -211,7 +212,7 @@ def sdsp(x: torch.Tensor, data_range: Union[int, float] = 255, omega_0: float = 
 
     x_lab = rgb2lab(x, data_range=255)
 
-    lg = _log_gabor(size_to_use, omega_0, sigma_f).to(x).view(1, 1, *size_to_use)
+    lg = _log_gabor(size_to_use, omega_0, sigma_f, device=x.device, dtype=x.dtype).view(1, 1, *size_to_use)
     recommended_torch_version = _parse_version('1.8.0')
     torch_version = _parse_version(torch.__version__)
     if len(torch_version) != 0 and torch_version >= recommended_torch_version:
@@ -223,7 +224,7 @@ def sdsp(x: torch.Tensor, data_range: Union[int, float] = 255, omega_0: float = 
 
     s_f = x_ifft_real.pow(2).sum(dim=1, keepdim=True).sqrt()
 
-    coordinates = torch.stack(get_meshgrid(size_to_use), dim=0).to(x)
+    coordinates = torch.stack(get_meshgrid(size_to_use, device=x.device, dtype=x.dtype), dim=0)
     coordinates = coordinates * size_to_use[0] + 1
     s_d = torch.exp(-torch.sum(coordinates ** 2, dim=0) / sigma_d ** 2).view(1, 1, *size_to_use)
 
@@ -242,18 +243,20 @@ def sdsp(x: torch.Tensor, data_range: Union[int, float] = 255, omega_0: float = 
     return (vs_m - min_vs_m) / (max_vs_m - min_vs_m + eps)
 
 
-def _log_gabor(size: Tuple[int, int], omega_0: float, sigma_f: float) -> torch.Tensor:
+def _log_gabor(size: Tuple[int, int], omega_0: float, sigma_f: float,
+               device: str = None, dtype: type = None) -> torch.Tensor:
     r"""Creates log Gabor filter
 
     Args:
         size: size of the requires log Gabor filter
         omega_0: center frequency of the filter
         sigma_f: bandwidth of the filter
-
+        device: target device for kernel generation
+        dtype: target data type for kernel generation
     Returns:
         log Gabor filter
     """
-    xx, yy = get_meshgrid(size)
+    xx, yy = get_meshgrid(size, device=device, dtype=dtype)
 
     radius = (xx ** 2 + yy ** 2).sqrt()
     mask = radius <= 0.5

--- a/tests/results_benchmark.py
+++ b/tests/results_benchmark.py
@@ -356,7 +356,8 @@ if __name__ == "__main__":
     parser.add_argument('--metrics', nargs='+', default=[], help='Metrics to benchmark',
                         choices=list(METRICS.keys()) + list(METRIC_CATEGORIES.keys()) + ['all'])
     parser.add_argument('--batch_size', type=int, default=1, help='Batch size')
-    parser.add_argument('--device', default='cuda', choices=['cpu', 'cuda'], help='Computation device')
+    device_choice = ['cpu', 'cuda'] + [f'cuda:{i}' for i in range(torch.cuda.device_count())]
+    parser.add_argument('--device', default='cuda', choices=device_choice, help='Computation device')
     parser.add_argument('--feature_extractor', default='inception', choices=['inception', 'vgg16', 'vgg19'],
                         help='Select a feature extractor. For distribution-based metrics only')
 

--- a/tests/test_srsim.py
+++ b/tests/test_srsim.py
@@ -12,7 +12,7 @@ def test_srsim_to_be_one_for_identical_inputs(input_tensors: Tuple[torch.Tensor,
     index = srsim(prediction.to(device), prediction.to(device), data_range=1., reduction='none')
 
     prediction_255 = (prediction * 255).type(torch.uint8)
-    index_255 = srsim(prediction_255, prediction_255, data_range=255, reduction='none')
+    index_255 = srsim(prediction_255.to(device), prediction_255.to(device), data_range=255, reduction='none')
     assert torch.allclose(index, torch.ones_like(index, device=device)), \
         f'Expected index to be equal 1, got {index}'
     assert torch.allclose(index_255, torch.ones_like(index_255, device=device)), \


### PR DESCRIPTION
Closes #266 
Addresses the second part of #227 

## Proposed Changes
- FSIM: got rid of a duplicate for filter generation `_construct_filters`
- FSIM: removed the duplicate of mesh grid generation performed for `_lowpassfilter`. The filter is computed explicitly.
- FSIM: minor optimisation of tensor generations across the `fsim` to avoid transfer between devices
- base.py: mesh grid creation (`get_meshgrid`) is performed straight on target device and data type according to input tensor without redundant transfers between devices
- base.py: removed redundant `to()` operation in `gradient_map`
- filters: filters are generated straight on target device and data type according to input tensor without redundant transfers between devices
- colour_conversion: moved tensor generation to the target device instead of transfer between devices
- Updated `.gitignore`
- minor change in benchmark script to allow more flexible choice for GPU device
- minor fixes across the code to match the changes for colour conversion and filter generation

## Outcome of the Proposed Changes

- Reduced cpu usage with `cuda`-enabled computations for FSIM and FSIMc (visual comparison is atttached)
- CPU time was reduced by 6 sec according to PyTorch profiler

## Note
Other places to consider for additional assessment of leaks
- `piq/base.py`,  `fid.py`, `perceptual.py` and `pieapp.py` use `.to()` for a various transfers. They are out of scope for current PR due to a different purpose of the transfer between devices/types.
- custom made `piq/functional/resize.py` could be refactored as well to get rid of redundant transfers. Added to #227 
- `vsi.py` has redundant mesh grid creation. Opened #335 


# Appendix 
## Visual Comparison of CPU usage
`htop` following #266 

### Before
Branch: master
<img width="981" alt="Screenshot 2023-02-05 at 00 42 23" src="https://user-images.githubusercontent.com/22414094/216795789-d1442ad7-3093-4a65-bf58-3007a773da1f.png">

### After
Branch: bug/cpu_usage
<img width="1016" alt="Screenshot 2023-02-05 at 00 38 06" src="https://user-images.githubusercontent.com/22414094/216795795-e9153ed0-eefe-44c0-9374-f1a4aa780c92.png">



## PyTorch Profiler Results. Top-8 operations.
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                        model_inference        16.38%        8.624s       100.00%       52.639s       52.639s             1  
                                               aten::to         0.07%      37.231ms        68.84%       36.234s       1.020ms         35525  
                                         aten::_to_copy         0.14%      72.795ms        68.76%       36.197s       4.993ms          7250  
                                            aten::copy_         0.34%     177.512ms        61.16%       32.196s       2.019ms         15950  
                                  cudaStreamSynchronize        40.22%       21.173s        40.22%       21.173s       1.718ms         12325  
                                        cudaMemcpyAsync        20.68%       10.883s        20.68%       10.883s     883.015us         12325  
                                    aten::empty_strided         0.17%      88.161ms         7.78%        4.093s     564.510us          7250  
                                             cudaMalloc         7.62%        4.009s         7.62%        4.009s     129.312ms            31  
```
