### PR TITLE
Update Testing CI to Cover Current Supporting Versions of Python and PyTorch

### DIFF
--- a/.github/workflows/ci-linting.yml
+++ b/.github/workflows/ci-linting.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6]
+        python-version: 3.11
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-linting.yml
+++ b/.github/workflows/ci-linting.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: 3.11
+        python-version: 3.10
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-linting.yml
+++ b/.github/workflows/ci-linting.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: 3.10
+        python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-mypy.yml
+++ b/.github/workflows/ci-mypy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: 3.11
+        python-version: 3.10
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-mypy.yml
+++ b/.github/workflows/ci-mypy.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: 3.11
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-mypy.yml
+++ b/.github/workflows/ci-mypy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: 3.10
+        python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.11]
+        python-version: [3.7, 3.10]
         torchvision-version: [0.6.1, 0.14.1]
 
     steps:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.10]
-        torchvision-version: [0.6.1, 0.14.1]
+        python-version: ["3.7", "3.10"]
+        torchvision-version: ["0.6.1", "0.14.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -9,15 +9,15 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: '3.6'
+      USING_COVERAGE: '3.7'
 
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        torchvision-version: [0.6.1, 0.9.1]
+        python-version: [3.7, 3.11]
+        torchvision-version: [0.6.1, 0.14.1]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install torchvision==${{ matrix.torchvision-version }}
           pip install -r requirements.txt
           pip install pytest \

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -16,8 +16,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.10"]
-        torchvision-version: ["0.6.1", "0.14.1"]
+        include:
+          - python-version: "3.7"
+            torchvision-version: "0.6.1"
+          - python-version: "3.7"
+            torchvision-version: "0.14.1"
+          - python-version: "3.10"
+            torchvision-version: "0.14.1"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ We provide:
 * Extensive user input validation. Your code will not crash in the middle of the training.
 * Fast (GPU computations available) and reliable.
 * Most metrics can be backpropagated for model optimization.
-* Supports python 3.6-3.8.
+* Supports python 3.7-3.10.
 
 PIQ was initially named `PhotoSynthesis.Metrics <https://pypi.org/project/photosynthesis-metrics/0.4.0/>`_.
 

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -35,12 +35,12 @@ def prepare_test(scipy_version='1.3.3', gudhi_version='3.2') -> None:
     try:
         import scipy  # noqa: F401
     except ImportError:
-        install('scipy' + '==' + scipy_version)
+        install('scipy' + '>=' + scipy_version)
 
     try:
         import gudhi  # noqa: F401
     except ImportError:
-        install('gudhi' + '==' + gudhi_version)
+        install('gudhi' + '>=' + gudhi_version)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #336 

## Proposed Changes
- changes OS to `ubuntu-latest`
- use `python 3.10` for linting and mypy checks
- shift testing CI to `python 3.7,3.10` and `torchvision 0.6.1, 0.14.1`
- relax versions for `scipy` and `gudhi`

TODO: Update required checks for Repo after review