### PR TITLE
Add meshgrid indexing

### DIFF
--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -31,7 +31,7 @@ def get_meshgrid(size: Tuple[int, int], device: Optional[str] = None, dtype: Opt
     else:
         # Even
         y = torch.arange(- size[1] / 2, size[1] / 2, device=device, dtype=dtype) / size[1]
-    return torch.meshgrid(x, y)
+    return torch.meshgrid(x, y, indexing='ij')
 
 
 def similarity_map(map_x: torch.Tensor, map_y: torch.Tensor, constant: float, alpha: float = 0.0) -> torch.Tensor:

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -3,6 +3,7 @@ from typing import Tuple, Union, Optional
 import torch
 from piq.utils import _parse_version
 
+
 def ifftshift(x: torch.Tensor) -> torch.Tensor:
     r""" Similar to np.fft.ifftshift but applies to PyTorch Tensors"""
     shift = [-(ax // 2) for ax in x.size()]

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -1,7 +1,7 @@
 r"""General purpose functions"""
 from typing import Tuple, Union, Optional
 import torch
-
+from piq.utils import _parse_version
 
 def ifftshift(x: torch.Tensor) -> torch.Tensor:
     r""" Similar to np.fft.ifftshift but applies to PyTorch Tensors"""

--- a/piq/functional/base.py
+++ b/piq/functional/base.py
@@ -31,7 +31,12 @@ def get_meshgrid(size: Tuple[int, int], device: Optional[str] = None, dtype: Opt
     else:
         # Even
         y = torch.arange(- size[1] / 2, size[1] / 2, device=device, dtype=dtype) / size[1]
-    return torch.meshgrid(x, y, indexing='ij')
+    # Use indexing param depending on torch version
+    recommended_torch_version = _parse_version("1.10.0")
+    torch_version = _parse_version(torch.__version__)
+    if len(torch_version) > 0 and torch_version >= recommended_torch_version:
+        return torch.meshgrid(x, y, indexing='ij')
+    return torch.meshgrid(x, y)
 
 
 def similarity_map(map_x: torch.Tensor, map_y: torch.Tensor, constant: float, alpha: float = 0.0) -> torch.Tensor:


### PR DESCRIPTION
torch.meshgrid(*tensors) currently has the same behavior as calling numpy.meshgrid(*arrays, indexing=’ij’).

In the future torch.meshgrid will transition to indexing=’xy’ as the default, so this change is necessary to keep the same functionality.

More info here: https://pytorch.org/docs/stable/generated/torch.meshgrid.html

Closes #358 

## Proposed Changes

  - Change torch.meshgrid(x, y) to torch.meshgrid(x, y, indexing='ij') [here](https://github.com/photosynthesis-team/piq/blob/3de9a2bdd34b2da26a3e15f63b7d70a21cea9bcf/piq/functional/base.py#L34)
